### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@
 
 name: Server CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master]


### PR DESCRIPTION
Potential fix for [https://github.com/revisium/revisium-endpoint/security/code-scanning/7](https://github.com/revisium/revisium-endpoint/security/code-scanning/7)

To fix the issue, we need to add a `permissions` key to the workflow. The goal is to limit the permissions granted to the `GITHUB_TOKEN` to only what is necessary for the tasks performed by the workflow. For this particular workflow:
- The `contents: read` permission is sufficient for accessing repository files and performing node-related tasks.
- No other permissions like `write` or `pull-requests` are needed based on the current steps in the workflow.

The `permissions` block should be added at the root level of the workflow so that it applies to all jobs within the workflow unless a specific job requires its own permissions block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions to enhance security for the Server CI pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->