### PR TITLE
fix: forward X-Api-Key and ?api_key= to core API on generated endpoints

### DIFF
--- a/src/endpoint-microservice/graphql/graphql-endpoint.service.ts
+++ b/src/endpoint-microservice/graphql/graphql-endpoint.service.ts
@@ -182,9 +182,9 @@ export class GraphqlEndpointService {
         if (
           !headers['x-api-key'] &&
           !headers.authorization &&
-          req.query.api_key
+          typeof req.query.api_key === 'string'
         ) {
-          headers['x-api-key'] = req.query.api_key as string;
+          headers['x-api-key'] = req.query.api_key;
         }
 
         return { headers };

--- a/src/endpoint-microservice/graphql/graphql-endpoint.service.ts
+++ b/src/endpoint-microservice/graphql/graphql-endpoint.service.ts
@@ -176,9 +176,19 @@ export class GraphqlEndpointService {
 
   private createMiddleware(apollo: ApolloServer): RequestHandler {
     return expressMiddleware(apollo, {
-      context: async ({ req }) => ({
-        headers: parseHeaders(req.headers),
-      }),
+      context: async ({ req }) => {
+        const headers = parseHeaders(req.headers);
+
+        if (
+          !headers['x-api-key'] &&
+          !headers.authorization &&
+          req.query.api_key
+        ) {
+          headers['x-api-key'] = req.query.api_key as string;
+        }
+
+        return { headers };
+      },
     });
   }
 

--- a/src/endpoint-microservice/restapi/controllers/__tests__/base-restapi-parseHeaders.spec.ts
+++ b/src/endpoint-microservice/restapi/controllers/__tests__/base-restapi-parseHeaders.spec.ts
@@ -1,0 +1,76 @@
+import { Request } from 'express';
+import { RestapiEndpointService } from 'src/endpoint-microservice/restapi/restapi-endpoint.service';
+import { BaseRestapiController } from '../base-restapi.controller';
+
+class TestController extends BaseRestapiController {
+  constructor() {
+    super(null as unknown as RestapiEndpointService);
+  }
+
+  public testParseHeaders(req: Partial<Request>): Record<string, string> {
+    return this.parseHeaders(req as Request);
+  }
+}
+
+describe('BaseRestapiController.parseHeaders', () => {
+  let controller: TestController;
+
+  beforeEach(() => {
+    controller = new TestController();
+  });
+
+  it('should forward authorization header', () => {
+    const result = controller.testParseHeaders({
+      headers: { authorization: 'Bearer token' } as any,
+      query: {},
+    });
+
+    expect(result.authorization).toBe('Bearer token');
+  });
+
+  it('should forward x-api-key header', () => {
+    const result = controller.testParseHeaders({
+      headers: { 'x-api-key': 'rev_testkey123456789012' } as any,
+      query: {},
+    });
+
+    expect(result['x-api-key']).toBe('rev_testkey123456789012');
+  });
+
+  it('should convert ?api_key= query param to x-api-key header', () => {
+    const result = controller.testParseHeaders({
+      headers: {} as any,
+      query: { api_key: 'rev_querykey12345678901' },
+    });
+
+    expect(result['x-api-key']).toBe('rev_querykey12345678901');
+  });
+
+  it('should not use query param when x-api-key header present', () => {
+    const result = controller.testParseHeaders({
+      headers: { 'x-api-key': 'rev_headerkey1234567890' } as any,
+      query: { api_key: 'rev_querykey12345678901' },
+    });
+
+    expect(result['x-api-key']).toBe('rev_headerkey1234567890');
+  });
+
+  it('should not use query param when authorization header present', () => {
+    const result = controller.testParseHeaders({
+      headers: { authorization: 'Bearer token' } as any,
+      query: { api_key: 'rev_querykey12345678901' },
+    });
+
+    expect(result['x-api-key']).toBeUndefined();
+    expect(result.authorization).toBe('Bearer token');
+  });
+
+  it('should return empty headers when no auth present', () => {
+    const result = controller.testParseHeaders({
+      headers: {} as any,
+      query: {},
+    });
+
+    expect(Object.keys(result)).toHaveLength(0);
+  });
+});

--- a/src/endpoint-microservice/restapi/controllers/base-restapi.controller.ts
+++ b/src/endpoint-microservice/restapi/controllers/base-restapi.controller.ts
@@ -34,8 +34,12 @@ export abstract class BaseRestapiController {
   protected parseHeaders(req: Request): Record<string, string> {
     const headers = parseHeaders(req.headers);
 
-    if (!headers['x-api-key'] && !headers.authorization && req.query.api_key) {
-      headers['x-api-key'] = req.query.api_key as string;
+    if (
+      !headers['x-api-key'] &&
+      !headers.authorization &&
+      typeof req.query.api_key === 'string'
+    ) {
+      headers['x-api-key'] = req.query.api_key;
     }
 
     return headers;

--- a/src/endpoint-microservice/restapi/controllers/base-restapi.controller.ts
+++ b/src/endpoint-microservice/restapi/controllers/base-restapi.controller.ts
@@ -32,6 +32,12 @@ export abstract class BaseRestapiController {
   }
 
   protected parseHeaders(req: Request): Record<string, string> {
-    return parseHeaders(req.headers);
+    const headers = parseHeaders(req.headers);
+
+    if (!headers['x-api-key'] && !headers.authorization && req.query.api_key) {
+      headers['x-api-key'] = req.query.api_key as string;
+    }
+
+    return headers;
   }
 }

--- a/src/endpoint-microservice/shared/utils/__tests__/parseHeaders.spec.ts
+++ b/src/endpoint-microservice/shared/utils/__tests__/parseHeaders.spec.ts
@@ -1,0 +1,49 @@
+import { parseHeaders } from '../parseHeaders';
+
+describe('parseHeaders', () => {
+  it('should forward authorization header', () => {
+    const result = parseHeaders({
+      authorization: 'Bearer token123',
+    });
+
+    expect(result.authorization).toBe('Bearer token123');
+  });
+
+  it('should forward x-api-key header', () => {
+    const result = parseHeaders({
+      'x-api-key': 'rev_testkey123456789012',
+    });
+
+    expect(result['x-api-key']).toBe('rev_testkey123456789012');
+  });
+
+  it('should forward both authorization and x-api-key headers', () => {
+    const result = parseHeaders({
+      authorization: 'Bearer token123',
+      'x-api-key': 'rev_testkey123456789012',
+    });
+
+    expect(result.authorization).toBe('Bearer token123');
+    expect(result['x-api-key']).toBe('rev_testkey123456789012');
+  });
+
+  it('should not forward other headers', () => {
+    const result = parseHeaders({
+      authorization: 'Bearer token',
+      'content-type': 'application/json',
+      'x-custom-header': 'value',
+    });
+
+    expect(result.authorization).toBe('Bearer token');
+    expect(result['content-type']).toBeUndefined();
+    expect(result['x-custom-header']).toBeUndefined();
+  });
+
+  it('should return empty object when no auth headers present', () => {
+    const result = parseHeaders({
+      'content-type': 'application/json',
+    });
+
+    expect(Object.keys(result)).toHaveLength(0);
+  });
+});

--- a/src/endpoint-microservice/shared/utils/parseHeaders.ts
+++ b/src/endpoint-microservice/shared/utils/parseHeaders.ts
@@ -9,5 +9,9 @@ export const parseHeaders = (
     headers.authorization = incomeHeaders.authorization;
   }
 
+  if (incomeHeaders['x-api-key']) {
+    headers['x-api-key'] = incomeHeaders['x-api-key'] as string;
+  }
+
   return headers;
 };


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure generated REST and GraphQL endpoints forward API key credentials to the core API. We pass `x-api-key` from headers and support `?api_key=` when no auth header is present, with a `typeof` guard to avoid multi-value issues.

- **Bug Fixes**
  - Forward `x-api-key` in `parseHeaders`; ignore non-auth headers.
  - Map `?api_key=` to `x-api-key` in REST and GraphQL only when neither `x-api-key` nor `authorization` is set; use `typeof req.query.api_key === 'string'`.
  - Added unit tests for `parseHeaders` and `BaseRestapiController.parseHeaders`, covering precedence and filtering.

<sup>Written for commit 58183e4cfd193dc605a050c40da8aa22d2de37f4. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-endpoint/pull/173">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

