### PR TITLE
feat: add X-Api-Key auth scheme to generated OpenAPI spec

### DIFF
--- a/src/endpoint-microservice/restapi/__tests__/snapshots/complex-schema.openapi.json
+++ b/src/endpoint-microservice/restapi/__tests__/snapshots/complex-schema.openapi.json
@@ -40,6 +40,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -211,6 +214,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -299,6 +305,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -406,6 +415,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -513,6 +525,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -624,6 +639,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -668,6 +686,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -759,6 +780,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -894,6 +918,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -1029,6 +1056,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -1167,6 +1197,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -1221,6 +1254,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -1389,6 +1425,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -1560,6 +1599,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -1648,6 +1690,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -1755,6 +1800,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -1862,6 +1910,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -1973,6 +2024,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -2017,6 +2071,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -2108,6 +2165,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -2243,6 +2303,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -2378,6 +2441,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -2516,6 +2582,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -2570,6 +2639,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -2738,6 +2810,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -2906,6 +2981,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -3077,6 +3155,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -3165,6 +3246,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -3272,6 +3356,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -3379,6 +3466,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -3490,6 +3580,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -3534,6 +3627,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -3625,6 +3721,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -3760,6 +3859,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -3895,6 +3997,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -4033,6 +4138,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -4087,6 +4195,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -4258,6 +4369,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -4346,6 +4460,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -4453,6 +4570,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -4560,6 +4680,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -4671,6 +4794,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -4715,6 +4841,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -4806,6 +4935,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -4941,6 +5073,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -5076,6 +5211,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -5214,6 +5352,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -5268,6 +5409,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -5439,6 +5583,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -5527,6 +5674,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -5634,6 +5784,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -5741,6 +5894,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -5852,6 +6008,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -5896,6 +6055,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -5987,6 +6149,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -6122,6 +6287,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -6257,6 +6425,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -6395,6 +6566,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -6449,6 +6623,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -6620,6 +6797,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -6708,6 +6888,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -6815,6 +6998,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -6922,6 +7108,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -7033,6 +7222,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -7077,6 +7269,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -7168,6 +7363,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -7303,6 +7501,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -7438,6 +7639,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -7576,6 +7780,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -7630,6 +7837,9 @@
         "security": [
           {
             "access-token": []
+          },
+          {
+            "api-key": []
           }
         ],
         "tags": [
@@ -7797,6 +8007,12 @@
         "scheme": "bearer",
         "bearerFormat": "JWT",
         "type": "http"
+      },
+      "api-key": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Api-Key",
+        "description": "API Key (rev_...) for programmatic access"
       }
     },
     "schemas": {

--- a/src/endpoint-microservice/restapi/__tests__/snapshots/complex-schema.openapi.json
+++ b/src/endpoint-microservice/restapi/__tests__/snapshots/complex-schema.openapi.json
@@ -201,7 +201,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       }
@@ -291,7 +291,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -401,7 +401,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "409": {
             "description": "Conflict - row with this ID already exists"
@@ -511,7 +511,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -625,7 +625,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -670,7 +670,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -764,7 +764,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -907,7 +907,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       },
@@ -1045,7 +1045,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       },
@@ -1186,7 +1186,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       },
@@ -1241,7 +1241,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       }
@@ -1409,7 +1409,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -1586,7 +1586,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       }
@@ -1676,7 +1676,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -1786,7 +1786,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "409": {
             "description": "Conflict - row with this ID already exists"
@@ -1896,7 +1896,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -2010,7 +2010,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -2055,7 +2055,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -2149,7 +2149,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -2292,7 +2292,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       },
@@ -2430,7 +2430,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       },
@@ -2571,7 +2571,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       },
@@ -2626,7 +2626,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       }
@@ -2794,7 +2794,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -2965,7 +2965,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -3142,7 +3142,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       }
@@ -3232,7 +3232,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -3342,7 +3342,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "409": {
             "description": "Conflict - row with this ID already exists"
@@ -3452,7 +3452,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -3566,7 +3566,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -3611,7 +3611,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -3705,7 +3705,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -3848,7 +3848,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       },
@@ -3986,7 +3986,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       },
@@ -4127,7 +4127,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       },
@@ -4182,7 +4182,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       }
@@ -4356,7 +4356,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       }
@@ -4446,7 +4446,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -4556,7 +4556,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "409": {
             "description": "Conflict - row with this ID already exists"
@@ -4666,7 +4666,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -4780,7 +4780,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -4825,7 +4825,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -4919,7 +4919,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -5062,7 +5062,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       },
@@ -5200,7 +5200,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       },
@@ -5341,7 +5341,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       },
@@ -5396,7 +5396,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       }
@@ -5570,7 +5570,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       }
@@ -5660,7 +5660,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -5770,7 +5770,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "409": {
             "description": "Conflict - row with this ID already exists"
@@ -5880,7 +5880,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -5994,7 +5994,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -6039,7 +6039,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -6133,7 +6133,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -6276,7 +6276,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       },
@@ -6414,7 +6414,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       },
@@ -6555,7 +6555,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       },
@@ -6610,7 +6610,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       }
@@ -6784,7 +6784,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       }
@@ -6874,7 +6874,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -6984,7 +6984,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "409": {
             "description": "Conflict - row with this ID already exists"
@@ -7094,7 +7094,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -7208,7 +7208,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -7253,7 +7253,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -7347,7 +7347,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"
@@ -7490,7 +7490,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       },
@@ -7628,7 +7628,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       },
@@ -7769,7 +7769,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       },
@@ -7824,7 +7824,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           }
         }
       }
@@ -7992,7 +7992,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized - invalid or missing token"
+            "description": "Unauthorized - invalid or missing access token or API key"
           },
           "404": {
             "description": "Not found"

--- a/src/endpoint-microservice/restapi/queries/handlers/get-open-api-schema.handler.ts
+++ b/src/endpoint-microservice/restapi/queries/handlers/get-open-api-schema.handler.ts
@@ -51,6 +51,12 @@ export class GetOpenApiSchemaHandler implements IQueryHandler<GetOpenApiSchemaQu
             bearerFormat: 'JWT',
             type: 'http',
           },
+          'api-key': {
+            type: 'apiKey',
+            in: 'header',
+            name: 'X-Api-Key',
+            description: 'API Key (rev_...) for programmatic access',
+          },
         },
         schemas: {
           ...getFilterAndSortSchemas(projectName),

--- a/src/endpoint-microservice/restapi/queries/handlers/open-api-schema.utils.ts
+++ b/src/endpoint-microservice/restapi/queries/handlers/open-api-schema.utils.ts
@@ -436,7 +436,7 @@ export const createQueryRowsPath = (
       operationId: getOperationId('list', info.rawTableId),
       summary: `Query ${info.rawTableId} rows`,
       description: `Returns a paginated list of ${info.rawTableId} rows with filtering and sorting`,
-      security: [{ 'access-token': [] }],
+      security: [{ 'access-token': [] }, { 'api-key': [] }],
       tags: [info.tag],
       requestBody: {
         required: true,
@@ -472,7 +472,7 @@ export const createSingleRowPath = (
       operationId: getOperationId('get', info.rawTableId),
       summary: `Get ${info.rawTableId} by ID`,
       description: `Returns a single ${info.rawTableId} row by its ID`,
-      security: [{ 'access-token': [] }],
+      security: [{ 'access-token': [] }, { 'api-key': [] }],
       tags: [info.tag],
       parameters: [getRowIdPathParam()],
       responses: {
@@ -504,7 +504,7 @@ export const createSingleRowPath = (
       operationId: getOperationId('create', info.rawTableId),
       summary: `Create ${info.rawTableId}`,
       description: `Creates a new ${info.rawTableId} row with the specified ID`,
-      security: [{ 'access-token': [] }],
+      security: [{ 'access-token': [] }, { 'api-key': [] }],
       tags: [info.tag],
       parameters: [getRowIdPathParam()],
       requestBody: dataRequestBody,
@@ -519,7 +519,7 @@ export const createSingleRowPath = (
       operationId: getOperationId('update', info.rawTableId),
       summary: `Update ${info.rawTableId}`,
       description: `Updates an existing ${info.rawTableId} row (full replacement)`,
-      security: [{ 'access-token': [] }],
+      security: [{ 'access-token': [] }, { 'api-key': [] }],
       tags: [info.tag],
       parameters: [getRowIdPathParam()],
       requestBody: dataRequestBody,
@@ -534,7 +534,7 @@ export const createSingleRowPath = (
       operationId: getOperationId('patch', info.rawTableId),
       summary: `Patch ${info.rawTableId}`,
       description: `Partially updates a ${info.rawTableId} row using JSON Patch operations`,
-      security: [{ 'access-token': [] }],
+      security: [{ 'access-token': [] }, { 'api-key': [] }],
       tags: [info.tag],
       parameters: [getRowIdPathParam()],
       requestBody: {
@@ -567,7 +567,7 @@ export const createSingleRowPath = (
       operationId: getOperationId('delete', info.rawTableId),
       summary: `Delete ${info.rawTableId}`,
       description: `Deletes a ${info.rawTableId} row by its ID`,
-      security: [{ 'access-token': [] }],
+      security: [{ 'access-token': [] }, { 'api-key': [] }],
       tags: [info.tag],
       parameters: [getRowIdPathParam()],
       responses: {
@@ -592,7 +592,7 @@ export const createForeignKeyPath = (
       operationId: getForeignKeyOperationId(info.rawTableId, fkInfo.rawTableId),
       summary: `Get ${info.rawTableId} foreign keys by ${fkInfo.rawTableId}`,
       description: `Returns rows from ${fkInfo.rawTableId} that reference this ${info.rawTableId}`,
-      security: [{ 'access-token': [] }],
+      security: [{ 'access-token': [] }, { 'api-key': [] }],
       tags: [info.tag],
       parameters: [getRowIdPathParam(), ...getPaginationParams()],
       responses: {
@@ -614,7 +614,7 @@ export const createFileUploadPath = (
     operationId: `upload${capitalize(info.rawTableId)}File`,
     summary: `Upload file for ${info.rawTableId}`,
     description: `Uploads a file to a specific field in the ${info.rawTableId} row`,
-    security: [{ 'access-token': [] }],
+    security: [{ 'access-token': [] }, { 'api-key': [] }],
     tags: [info.tag],
     parameters: [
       getRowIdPathParam(),
@@ -772,7 +772,7 @@ const createBulkOperation = (
   operationId: getBulkOperationId(config.operation, info.rawTableId),
   summary: `Bulk ${config.operation} ${info.rawTableId} rows`,
   description: `${config.verb} multiple ${info.rawTableId} rows${config.descriptionSuffix ?? ''}. Maximum 1000 rows per request.`,
-  security: [{ 'access-token': [] }],
+  security: [{ 'access-token': [] }, { 'api-key': [] }],
   tags: [info.tag],
   requestBody: {
     required: true,

--- a/src/endpoint-microservice/restapi/queries/handlers/open-api-schema.utils.ts
+++ b/src/endpoint-microservice/restapi/queries/handlers/open-api-schema.utils.ts
@@ -285,7 +285,7 @@ export const getPaginationParams = (): oas31.ParameterObject[] => [
 ];
 
 const UNAUTHORIZED_RESPONSE: oas31.ResponseObject = {
-  description: 'Unauthorized - invalid or missing token',
+  description: 'Unauthorized - invalid or missing access token or API key',
 };
 
 const NOT_FOUND_RESPONSE: oas31.ResponseObject = {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `api-key` security scheme to the generated OpenAPI using the `X-Api-Key` header.
All endpoints now accept either bearer `access-token` or `api-key`, and 401 Unauthorized descriptions mention both.

<sup>Written for commit 201e37b3647bbe19bacd1806608086c3bdd29f85. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-endpoint/pull/174">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

