### PR TITLE
feat: separate Input schemas for write request bodies

### DIFF
--- a/src/endpoint-microservice/restapi/__tests__/restapi-openapi-file-input.spec.ts
+++ b/src/endpoint-microservice/restapi/__tests__/restapi-openapi-file-input.spec.ts
@@ -1,0 +1,249 @@
+import { INestApplication } from '@nestjs/common';
+import { QueryBus } from '@nestjs/cqrs';
+import { Test, TestingModule } from '@nestjs/testing';
+import { oas31 } from 'openapi3-ts';
+import {
+  getObjectSchema,
+  getRefSchema,
+  getStringSchema,
+} from '@revisium/schema-toolkit/mocks';
+import { SystemSchemaIds } from '@revisium/schema-toolkit/consts';
+import { InternalCoreApiService } from 'src/endpoint-microservice/core-api/internal-core-api.service';
+import { ProxyCoreApiService } from 'src/endpoint-microservice/core-api/proxy-core-api.service';
+import { PrismaService } from 'src/endpoint-microservice/database/prisma.service';
+import { EndpointMicroserviceModule } from 'src/endpoint-microservice/endpoint-microservice.module';
+import { GetOpenApiSchemaQuery } from 'src/endpoint-microservice/restapi/queries/impl';
+import { OpenApiSchema } from 'src/endpoint-microservice/shared/types/open-api-schema';
+import { SystemTables } from 'src/endpoint-microservice/shared/system-tables.consts';
+
+const REVISION_ID = 'rev-1';
+const PROJECT_NAME = 'TestProject';
+const TABLE_ID = 'document';
+const SCHEMA_NAME = 'TestProjectDocument';
+const INPUT_SCHEMA_NAME = `${SCHEMA_NAME}Input`;
+
+const FILE_FIELDS = [
+  'status',
+  'fileId',
+  'url',
+  'fileName',
+  'hash',
+  'extension',
+  'mimeType',
+  'size',
+  'width',
+  'height',
+];
+
+const createSchemaTableData = () => ({
+  data: {
+    edges: [
+      {
+        node: {
+          id: TABLE_ID,
+          data: getObjectSchema({
+            title: getStringSchema(),
+            file: getRefSchema(SystemSchemaIds.File),
+          }),
+        },
+      },
+    ],
+    totalCount: 1,
+  },
+  error: null,
+});
+
+const createMockInternalCoreApiService = () => ({
+  initApi: jest.fn().mockResolvedValue(undefined),
+  api: {
+    login: jest.fn().mockResolvedValue({
+      data: { accessToken: 'mock-token' },
+      error: null,
+    }),
+    rows: jest
+      .fn()
+      .mockImplementation((_revisionId: string, tableId: string) => {
+        if (tableId === SystemTables.Schema) {
+          return Promise.resolve(createSchemaTableData());
+        }
+        return Promise.resolve({
+          data: { edges: [], totalCount: 0 },
+          error: null,
+        });
+      }),
+    revision: jest.fn().mockResolvedValue({
+      data: { isDraft: true },
+      error: null,
+    }),
+    tableForeignKeysBy: jest.fn().mockResolvedValue({
+      data: { edges: [] },
+      error: null,
+    }),
+    endpoints: jest.fn().mockResolvedValue({
+      data: { edges: [], totalCount: 0 },
+      error: null,
+    }),
+  },
+});
+
+const createMockProxyCoreApiService = () => ({ api: {} });
+
+const createMockPrismaService = () => ({
+  endpoint: { findMany: jest.fn().mockResolvedValue([]) },
+});
+
+const collectReadOnlyPaths = (
+  node: unknown,
+  trail: string[] = [],
+  hits: string[] = [],
+): string[] => {
+  if (!node || typeof node !== 'object') return hits;
+  const obj = node as Record<string, unknown>;
+  if (obj.readOnly === true) hits.push(trail.join('.') || '<root>');
+  for (const [key, value] of Object.entries(obj)) {
+    if (key === 'readOnly') continue;
+    collectReadOnlyPaths(value, [...trail, key], hits);
+  }
+  return hits;
+};
+
+describe('OpenAPI: write request bodies must not contain readOnly fields (issue #20)', () => {
+  let app: INestApplication;
+  let queryBus: QueryBus;
+  let openApiJson: OpenApiSchema;
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [EndpointMicroserviceModule.forRoot({ mode: 'monolith' })],
+    })
+      .overrideProvider(InternalCoreApiService)
+      .useValue(createMockInternalCoreApiService())
+      .overrideProvider(ProxyCoreApiService)
+      .useValue(createMockProxyCoreApiService())
+      .overrideProvider(PrismaService)
+      .useValue(createMockPrismaService())
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    queryBus = app.get(QueryBus);
+    openApiJson = await queryBus.execute<GetOpenApiSchemaQuery, OpenApiSchema>(
+      new GetOpenApiSchemaQuery({
+        revisionId: REVISION_ID,
+        projectName: PROJECT_NAME,
+      }),
+    );
+  });
+
+  afterAll(async () => {
+    await app.close();
+  }, 10000);
+
+  it('exposes both output and input schemas in components.schemas', () => {
+    const schemas = openApiJson.components?.schemas ?? {};
+    expect(schemas).toHaveProperty(SCHEMA_NAME);
+    expect(schemas).toHaveProperty(INPUT_SCHEMA_NAME);
+  });
+
+  it('input schema preserves all File subfields (no fields are dropped)', () => {
+    const inputSchema = openApiJson.components?.schemas?.[
+      INPUT_SCHEMA_NAME
+    ] as oas31.SchemaObject;
+    const file = inputSchema?.properties?.file as oas31.SchemaObject;
+    expect(file?.type).toBe('object');
+    expect(Object.keys(file.properties ?? {}).sort()).toEqual(
+      [...FILE_FIELDS].sort(),
+    );
+  });
+
+  it('input schema does not contain readOnly anywhere', () => {
+    const inputSchema = openApiJson.components?.schemas?.[INPUT_SCHEMA_NAME];
+    const readOnlyHits = collectReadOnlyPaths(inputSchema);
+    expect(readOnlyHits).toEqual([]);
+  });
+
+  it('output schema retains readOnly markers (response semantics preserved)', () => {
+    const outputSchema = openApiJson.components?.schemas?.[
+      SCHEMA_NAME
+    ] as oas31.SchemaObject;
+    const file = outputSchema?.properties?.file as oas31.SchemaObject;
+    const readOnlyChildren = Object.entries(file?.properties ?? {})
+      .filter(([, value]) => (value as oas31.SchemaObject).readOnly === true)
+      .map(([key]) => key)
+      .sort();
+    expect(readOnlyChildren).toEqual(
+      [
+        'status',
+        'fileId',
+        'url',
+        'hash',
+        'extension',
+        'mimeType',
+        'size',
+        'width',
+        'height',
+      ].sort(),
+    );
+  });
+
+  it('createRow request body references the input schema', () => {
+    const path = openApiJson.paths?.[`/tables/${TABLE_ID}/row/{rowId}`];
+    const body = path?.post?.requestBody as oas31.RequestBodyObject;
+    const schema = body?.content?.['application/json']
+      ?.schema as oas31.SchemaObject;
+    const dataRef = (schema?.properties?.data as oas31.ReferenceObject)?.$ref;
+    expect(dataRef).toBe(`#/components/schemas/${INPUT_SCHEMA_NAME}`);
+  });
+
+  it('updateRow (PUT) request body references the input schema', () => {
+    const path = openApiJson.paths?.[`/tables/${TABLE_ID}/row/{rowId}`];
+    const body = path?.put?.requestBody as oas31.RequestBodyObject;
+    const schema = body?.content?.['application/json']
+      ?.schema as oas31.SchemaObject;
+    const dataRef = (schema?.properties?.data as oas31.ReferenceObject)?.$ref;
+    expect(dataRef).toBe(`#/components/schemas/${INPUT_SCHEMA_NAME}`);
+  });
+
+  it('bulkCreate request body references the input schema', () => {
+    const path = openApiJson.paths?.[`/tables/${TABLE_ID}/rows/bulk`];
+    const body = path?.post?.requestBody as oas31.RequestBodyObject;
+    const schema = body?.content?.['application/json']
+      ?.schema as oas31.SchemaObject;
+    const items = (schema?.properties?.rows as oas31.SchemaObject)
+      ?.items as oas31.SchemaObject;
+    const dataRef = (items?.properties?.data as oas31.ReferenceObject)?.$ref;
+    expect(dataRef).toBe(`#/components/schemas/${INPUT_SCHEMA_NAME}`);
+  });
+
+  it('bulkUpdate (PUT) request body references the input schema', () => {
+    const path = openApiJson.paths?.[`/tables/${TABLE_ID}/rows/bulk`];
+    const body = path?.put?.requestBody as oas31.RequestBodyObject;
+    const schema = body?.content?.['application/json']
+      ?.schema as oas31.SchemaObject;
+    const items = (schema?.properties?.rows as oas31.SchemaObject)
+      ?.items as oas31.SchemaObject;
+    const dataRef = (items?.properties?.data as oas31.ReferenceObject)?.$ref;
+    expect(dataRef).toBe(`#/components/schemas/${INPUT_SCHEMA_NAME}`);
+  });
+
+  it('GET single row response still references the output schema (not input)', () => {
+    const path = openApiJson.paths?.[`/tables/${TABLE_ID}/row/{rowId}`];
+    const response = path?.get?.responses?.['200'] as oas31.ResponseObject;
+    const schema = response?.content?.['application/json']
+      ?.schema as oas31.SchemaObject;
+    const dataRef = (schema?.properties?.data as oas31.ReferenceObject)?.$ref;
+    expect(dataRef).toBe(`#/components/schemas/${SCHEMA_NAME}`);
+  });
+
+  it('createRow response still references the output schema (not input)', () => {
+    const path = openApiJson.paths?.[`/tables/${TABLE_ID}/row/{rowId}`];
+    const response = path?.post?.responses?.['200'] as oas31.ResponseObject;
+    const schema = response?.content?.['application/json']
+      ?.schema as oas31.SchemaObject;
+    const dataRef = (schema?.properties?.data as oas31.ReferenceObject)?.$ref;
+    expect(dataRef).toBe(`#/components/schemas/${SCHEMA_NAME}`);
+  });
+});

--- a/src/endpoint-microservice/restapi/__tests__/snapshots/complex-schema.openapi.json
+++ b/src/endpoint-microservice/restapi/__tests__/snapshots/complex-schema.openapi.json
@@ -336,7 +336,7 @@
                 ],
                 "properties": {
                   "data": {
-                    "$ref": "#/components/schemas/TestProjectAuthor"
+                    "$ref": "#/components/schemas/TestProjectAuthorInput"
                   }
                 }
               }
@@ -446,7 +446,7 @@
                 ],
                 "properties": {
                   "data": {
-                    "$ref": "#/components/schemas/TestProjectAuthor"
+                    "$ref": "#/components/schemas/TestProjectAuthorInput"
                   }
                 }
               }
@@ -815,7 +815,7 @@
                           "description": "Unique row identifier"
                         },
                         "data": {
-                          "$ref": "#/components/schemas/TestProjectAuthor",
+                          "$ref": "#/components/schemas/TestProjectAuthorInput",
                           "description": "Row data"
                         }
                       }
@@ -953,7 +953,7 @@
                           "description": "Unique row identifier"
                         },
                         "data": {
-                          "$ref": "#/components/schemas/TestProjectAuthor",
+                          "$ref": "#/components/schemas/TestProjectAuthorInput",
                           "description": "Row data"
                         }
                       }
@@ -1721,7 +1721,7 @@
                 ],
                 "properties": {
                   "data": {
-                    "$ref": "#/components/schemas/TestProjectCategory"
+                    "$ref": "#/components/schemas/TestProjectCategoryInput"
                   }
                 }
               }
@@ -1831,7 +1831,7 @@
                 ],
                 "properties": {
                   "data": {
-                    "$ref": "#/components/schemas/TestProjectCategory"
+                    "$ref": "#/components/schemas/TestProjectCategoryInput"
                   }
                 }
               }
@@ -2200,7 +2200,7 @@
                           "description": "Unique row identifier"
                         },
                         "data": {
-                          "$ref": "#/components/schemas/TestProjectCategory",
+                          "$ref": "#/components/schemas/TestProjectCategoryInput",
                           "description": "Row data"
                         }
                       }
@@ -2338,7 +2338,7 @@
                           "description": "Unique row identifier"
                         },
                         "data": {
-                          "$ref": "#/components/schemas/TestProjectCategory",
+                          "$ref": "#/components/schemas/TestProjectCategoryInput",
                           "description": "Row data"
                         }
                       }
@@ -3277,7 +3277,7 @@
                 ],
                 "properties": {
                   "data": {
-                    "$ref": "#/components/schemas/TestProjectMedia"
+                    "$ref": "#/components/schemas/TestProjectMediaInput"
                   }
                 }
               }
@@ -3387,7 +3387,7 @@
                 ],
                 "properties": {
                   "data": {
-                    "$ref": "#/components/schemas/TestProjectMedia"
+                    "$ref": "#/components/schemas/TestProjectMediaInput"
                   }
                 }
               }
@@ -3756,7 +3756,7 @@
                           "description": "Unique row identifier"
                         },
                         "data": {
-                          "$ref": "#/components/schemas/TestProjectMedia",
+                          "$ref": "#/components/schemas/TestProjectMediaInput",
                           "description": "Row data"
                         }
                       }
@@ -3894,7 +3894,7 @@
                           "description": "Unique row identifier"
                         },
                         "data": {
-                          "$ref": "#/components/schemas/TestProjectMedia",
+                          "$ref": "#/components/schemas/TestProjectMediaInput",
                           "description": "Row data"
                         }
                       }
@@ -4491,7 +4491,7 @@
                 ],
                 "properties": {
                   "data": {
-                    "$ref": "#/components/schemas/TestProjectPost"
+                    "$ref": "#/components/schemas/TestProjectPostInput"
                   }
                 }
               }
@@ -4601,7 +4601,7 @@
                 ],
                 "properties": {
                   "data": {
-                    "$ref": "#/components/schemas/TestProjectPost"
+                    "$ref": "#/components/schemas/TestProjectPostInput"
                   }
                 }
               }
@@ -4970,7 +4970,7 @@
                           "description": "Unique row identifier"
                         },
                         "data": {
-                          "$ref": "#/components/schemas/TestProjectPost",
+                          "$ref": "#/components/schemas/TestProjectPostInput",
                           "description": "Row data"
                         }
                       }
@@ -5108,7 +5108,7 @@
                           "description": "Unique row identifier"
                         },
                         "data": {
-                          "$ref": "#/components/schemas/TestProjectPost",
+                          "$ref": "#/components/schemas/TestProjectPostInput",
                           "description": "Row data"
                         }
                       }
@@ -5705,7 +5705,7 @@
                 ],
                 "properties": {
                   "data": {
-                    "$ref": "#/components/schemas/TestProjectSettings"
+                    "$ref": "#/components/schemas/TestProjectSettingsInput"
                   }
                 }
               }
@@ -5815,7 +5815,7 @@
                 ],
                 "properties": {
                   "data": {
-                    "$ref": "#/components/schemas/TestProjectSettings"
+                    "$ref": "#/components/schemas/TestProjectSettingsInput"
                   }
                 }
               }
@@ -6184,7 +6184,7 @@
                           "description": "Unique row identifier"
                         },
                         "data": {
-                          "$ref": "#/components/schemas/TestProjectSettings",
+                          "$ref": "#/components/schemas/TestProjectSettingsInput",
                           "description": "Row data"
                         }
                       }
@@ -6322,7 +6322,7 @@
                           "description": "Unique row identifier"
                         },
                         "data": {
-                          "$ref": "#/components/schemas/TestProjectSettings",
+                          "$ref": "#/components/schemas/TestProjectSettingsInput",
                           "description": "Row data"
                         }
                       }
@@ -6919,7 +6919,7 @@
                 ],
                 "properties": {
                   "data": {
-                    "$ref": "#/components/schemas/TestProjectTag"
+                    "$ref": "#/components/schemas/TestProjectTagInput"
                   }
                 }
               }
@@ -7029,7 +7029,7 @@
                 ],
                 "properties": {
                   "data": {
-                    "$ref": "#/components/schemas/TestProjectTag"
+                    "$ref": "#/components/schemas/TestProjectTagInput"
                   }
                 }
               }
@@ -7398,7 +7398,7 @@
                           "description": "Unique row identifier"
                         },
                         "data": {
-                          "$ref": "#/components/schemas/TestProjectTag",
+                          "$ref": "#/components/schemas/TestProjectTagInput",
                           "description": "Row data"
                         }
                       }
@@ -7536,7 +7536,7 @@
                           "description": "Unique row identifier"
                         },
                         "data": {
-                          "$ref": "#/components/schemas/TestProjectTag",
+                          "$ref": "#/components/schemas/TestProjectTagInput",
                           "description": "Row data"
                         }
                       }
@@ -8505,7 +8505,160 @@
           }
         }
       },
+      "TestProjectAuthorInput": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "age",
+          "avatar",
+          "bio",
+          "email",
+          "isVerified",
+          "name",
+          "socialLinks"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "default": ""
+          },
+          "email": {
+            "type": "string",
+            "default": ""
+          },
+          "bio": {
+            "type": "string",
+            "default": ""
+          },
+          "age": {
+            "type": "number",
+            "default": 0
+          },
+          "isVerified": {
+            "type": "boolean",
+            "default": false
+          },
+          "avatar": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "extension",
+              "fileId",
+              "fileName",
+              "hash",
+              "height",
+              "mimeType",
+              "size",
+              "status",
+              "url",
+              "width"
+            ],
+            "properties": {
+              "status": {
+                "type": "string",
+                "default": ""
+              },
+              "fileId": {
+                "type": "string",
+                "default": ""
+              },
+              "url": {
+                "type": "string",
+                "default": ""
+              },
+              "fileName": {
+                "type": "string",
+                "default": ""
+              },
+              "hash": {
+                "type": "string",
+                "default": ""
+              },
+              "extension": {
+                "type": "string",
+                "default": ""
+              },
+              "mimeType": {
+                "type": "string",
+                "default": ""
+              },
+              "size": {
+                "type": "number",
+                "default": 0
+              },
+              "width": {
+                "type": "number",
+                "default": 0
+              },
+              "height": {
+                "type": "number",
+                "default": 0
+              }
+            }
+          },
+          "socialLinks": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "platform",
+                "url"
+              ],
+              "properties": {
+                "platform": {
+                  "type": "string",
+                  "default": ""
+                },
+                "url": {
+                  "type": "string",
+                  "default": ""
+                }
+              }
+            }
+          }
+        }
+      },
       "TestProjectCategory": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "description",
+          "isActive",
+          "name",
+          "order",
+          "parent",
+          "slug"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "default": ""
+          },
+          "slug": {
+            "type": "string",
+            "default": ""
+          },
+          "description": {
+            "type": "string",
+            "default": ""
+          },
+          "parent": {
+            "type": "string",
+            "default": "",
+            "foreignKey": "category"
+          },
+          "order": {
+            "type": "number",
+            "default": 0
+          },
+          "isActive": {
+            "type": "boolean",
+            "default": false
+          }
+        }
+      },
+      "TestProjectCategoryInput": {
         "type": "object",
         "additionalProperties": false,
         "required": [
@@ -8619,6 +8772,107 @@
                 "type": "number",
                 "default": 0,
                 "readOnly": true
+              }
+            }
+          },
+          "alt": {
+            "type": "string",
+            "default": ""
+          },
+          "caption": {
+            "type": "string",
+            "default": ""
+          },
+          "type": {
+            "type": "string",
+            "default": ""
+          },
+          "dimensions": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "height",
+              "width"
+            ],
+            "properties": {
+              "width": {
+                "type": "number",
+                "default": 0
+              },
+              "height": {
+                "type": "number",
+                "default": 0
+              }
+            }
+          }
+        }
+      },
+      "TestProjectMediaInput": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "alt",
+          "caption",
+          "dimensions",
+          "file",
+          "type"
+        ],
+        "properties": {
+          "file": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "extension",
+              "fileId",
+              "fileName",
+              "hash",
+              "height",
+              "mimeType",
+              "size",
+              "status",
+              "url",
+              "width"
+            ],
+            "properties": {
+              "status": {
+                "type": "string",
+                "default": ""
+              },
+              "fileId": {
+                "type": "string",
+                "default": ""
+              },
+              "url": {
+                "type": "string",
+                "default": ""
+              },
+              "fileName": {
+                "type": "string",
+                "default": ""
+              },
+              "hash": {
+                "type": "string",
+                "default": ""
+              },
+              "extension": {
+                "type": "string",
+                "default": ""
+              },
+              "mimeType": {
+                "type": "string",
+                "default": ""
+              },
+              "size": {
+                "type": "number",
+                "default": 0
+              },
+              "width": {
+                "type": "number",
+                "default": 0
+              },
+              "height": {
+                "type": "number",
+                "default": 0
               }
             }
           },
@@ -8952,6 +9206,286 @@
           }
         }
       },
+      "TestProjectPostInput": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "author",
+          "category",
+          "comments",
+          "content",
+          "excerpt",
+          "featuredImage",
+          "gallery",
+          "isPublished",
+          "metadata",
+          "publishedAt",
+          "slug",
+          "tags",
+          "title",
+          "viewCount"
+        ],
+        "properties": {
+          "title": {
+            "type": "string",
+            "default": ""
+          },
+          "slug": {
+            "type": "string",
+            "default": ""
+          },
+          "content": {
+            "type": "string",
+            "default": ""
+          },
+          "excerpt": {
+            "type": "string",
+            "default": ""
+          },
+          "author": {
+            "type": "string",
+            "default": "",
+            "foreignKey": "author"
+          },
+          "category": {
+            "type": "string",
+            "default": "",
+            "foreignKey": "category"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": "",
+              "foreignKey": "tag"
+            }
+          },
+          "featuredImage": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "extension",
+              "fileId",
+              "fileName",
+              "hash",
+              "height",
+              "mimeType",
+              "size",
+              "status",
+              "url",
+              "width"
+            ],
+            "properties": {
+              "status": {
+                "type": "string",
+                "default": ""
+              },
+              "fileId": {
+                "type": "string",
+                "default": ""
+              },
+              "url": {
+                "type": "string",
+                "default": ""
+              },
+              "fileName": {
+                "type": "string",
+                "default": ""
+              },
+              "hash": {
+                "type": "string",
+                "default": ""
+              },
+              "extension": {
+                "type": "string",
+                "default": ""
+              },
+              "mimeType": {
+                "type": "string",
+                "default": ""
+              },
+              "size": {
+                "type": "number",
+                "default": 0
+              },
+              "width": {
+                "type": "number",
+                "default": 0
+              },
+              "height": {
+                "type": "number",
+                "default": 0
+              }
+            }
+          },
+          "gallery": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "extension",
+                "fileId",
+                "fileName",
+                "hash",
+                "height",
+                "mimeType",
+                "size",
+                "status",
+                "url",
+                "width"
+              ],
+              "properties": {
+                "status": {
+                  "type": "string",
+                  "default": ""
+                },
+                "fileId": {
+                  "type": "string",
+                  "default": ""
+                },
+                "url": {
+                  "type": "string",
+                  "default": ""
+                },
+                "fileName": {
+                  "type": "string",
+                  "default": ""
+                },
+                "hash": {
+                  "type": "string",
+                  "default": ""
+                },
+                "extension": {
+                  "type": "string",
+                  "default": ""
+                },
+                "mimeType": {
+                  "type": "string",
+                  "default": ""
+                },
+                "size": {
+                  "type": "number",
+                  "default": 0
+                },
+                "width": {
+                  "type": "number",
+                  "default": 0
+                },
+                "height": {
+                  "type": "number",
+                  "default": 0
+                }
+              }
+            }
+          },
+          "publishedAt": {
+            "type": "string",
+            "default": ""
+          },
+          "viewCount": {
+            "type": "number",
+            "default": 0
+          },
+          "isPublished": {
+            "type": "boolean",
+            "default": false
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "customFields",
+              "keywords",
+              "seoDescription",
+              "seoTitle"
+            ],
+            "properties": {
+              "seoTitle": {
+                "type": "string",
+                "default": ""
+              },
+              "seoDescription": {
+                "type": "string",
+                "default": ""
+              },
+              "keywords": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "default": ""
+                }
+              },
+              "customFields": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "field1",
+                  "field2"
+                ],
+                "properties": {
+                  "field1": {
+                    "type": "string",
+                    "default": ""
+                  },
+                  "field2": {
+                    "type": "number",
+                    "default": 0
+                  }
+                }
+              }
+            }
+          },
+          "comments": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "authorName",
+                "content",
+                "createdAt",
+                "replies"
+              ],
+              "properties": {
+                "authorName": {
+                  "type": "string",
+                  "default": ""
+                },
+                "content": {
+                  "type": "string",
+                  "default": ""
+                },
+                "createdAt": {
+                  "type": "string",
+                  "default": ""
+                },
+                "replies": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "authorName",
+                      "content"
+                    ],
+                    "properties": {
+                      "authorName": {
+                        "type": "string",
+                        "default": ""
+                      },
+                      "content": {
+                        "type": "string",
+                        "default": ""
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "TestProjectSettings": {
         "type": "object",
         "additionalProperties": false,
@@ -9105,7 +9639,169 @@
           }
         }
       },
+      "TestProjectSettingsInput": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "features",
+          "limits",
+          "logo",
+          "siteName",
+          "siteUrl",
+          "socialMedia"
+        ],
+        "properties": {
+          "siteName": {
+            "type": "string",
+            "default": ""
+          },
+          "siteUrl": {
+            "type": "string",
+            "default": ""
+          },
+          "logo": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "extension",
+              "fileId",
+              "fileName",
+              "hash",
+              "height",
+              "mimeType",
+              "size",
+              "status",
+              "url",
+              "width"
+            ],
+            "properties": {
+              "status": {
+                "type": "string",
+                "default": ""
+              },
+              "fileId": {
+                "type": "string",
+                "default": ""
+              },
+              "url": {
+                "type": "string",
+                "default": ""
+              },
+              "fileName": {
+                "type": "string",
+                "default": ""
+              },
+              "hash": {
+                "type": "string",
+                "default": ""
+              },
+              "extension": {
+                "type": "string",
+                "default": ""
+              },
+              "mimeType": {
+                "type": "string",
+                "default": ""
+              },
+              "size": {
+                "type": "number",
+                "default": 0
+              },
+              "width": {
+                "type": "number",
+                "default": 0
+              },
+              "height": {
+                "type": "number",
+                "default": 0
+              }
+            }
+          },
+          "socialMedia": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "facebook",
+              "instagram",
+              "twitter"
+            ],
+            "properties": {
+              "twitter": {
+                "type": "string",
+                "default": ""
+              },
+              "facebook": {
+                "type": "string",
+                "default": ""
+              },
+              "instagram": {
+                "type": "string",
+                "default": ""
+              }
+            }
+          },
+          "features": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "enableComments",
+              "enableNewsletter",
+              "maintenanceMode"
+            ],
+            "properties": {
+              "enableComments": {
+                "type": "boolean",
+                "default": false
+              },
+              "enableNewsletter": {
+                "type": "boolean",
+                "default": false
+              },
+              "maintenanceMode": {
+                "type": "boolean",
+                "default": false
+              }
+            }
+          },
+          "limits": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "maxUploadSize",
+              "postsPerPage"
+            ],
+            "properties": {
+              "maxUploadSize": {
+                "type": "number",
+                "default": 0
+              },
+              "postsPerPage": {
+                "type": "number",
+                "default": 0
+              }
+            }
+          }
+        }
+      },
       "TestProjectTag": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "color",
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "default": ""
+          },
+          "color": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "TestProjectTagInput": {
         "type": "object",
         "additionalProperties": false,
         "required": [

--- a/src/endpoint-microservice/restapi/queries/handlers/__tests__/open-api-schema.utils.spec.ts
+++ b/src/endpoint-microservice/restapi/queries/handlers/__tests__/open-api-schema.utils.spec.ts
@@ -1,0 +1,172 @@
+import { oas31 } from 'openapi3-ts';
+import { stripReadOnly } from '../open-api-schema.utils';
+
+describe('stripReadOnly', () => {
+  it('removes readOnly from a top-level property', () => {
+    const schema: oas31.SchemaObject = {
+      type: 'object',
+      properties: {
+        id: { type: 'string', readOnly: true },
+        name: { type: 'string' },
+      },
+    };
+
+    const result = stripReadOnly(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        name: { type: 'string' },
+      },
+    });
+  });
+
+  it('removes readOnly recursively in nested object properties', () => {
+    const schema: oas31.SchemaObject = {
+      type: 'object',
+      properties: {
+        file: {
+          type: 'object',
+          properties: {
+            status: { type: 'string', default: '', readOnly: true },
+            fileId: { type: 'string', default: '', readOnly: true },
+            fileName: { type: 'string', default: '' },
+          },
+        },
+      },
+    };
+
+    const result = stripReadOnly(schema);
+
+    expect(result.properties?.file).toEqual({
+      type: 'object',
+      properties: {
+        status: { type: 'string', default: '' },
+        fileId: { type: 'string', default: '' },
+        fileName: { type: 'string', default: '' },
+      },
+    });
+  });
+
+  it('removes readOnly inside array items', () => {
+    const schema: oas31.SchemaObject = {
+      type: 'object',
+      properties: {
+        files: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              fileId: { type: 'string', readOnly: true },
+              fileName: { type: 'string' },
+            },
+          },
+        },
+      },
+    };
+
+    const result = stripReadOnly(schema);
+
+    expect((result.properties?.files as oas31.SchemaObject)?.items).toEqual({
+      type: 'object',
+      properties: {
+        fileId: { type: 'string' },
+        fileName: { type: 'string' },
+      },
+    });
+  });
+
+  it('preserves default, type, description, required, additionalProperties', () => {
+    const schema: oas31.SchemaObject = {
+      type: 'object',
+      additionalProperties: false,
+      required: ['name', 'id'],
+      properties: {
+        id: {
+          type: 'string',
+          default: '',
+          description: 'Identifier',
+          readOnly: true,
+        },
+        name: { type: 'string', default: '', description: 'Display name' },
+      },
+    };
+
+    const result = stripReadOnly(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      additionalProperties: false,
+      required: ['name', 'id'],
+      properties: {
+        id: { type: 'string', default: '', description: 'Identifier' },
+        name: { type: 'string', default: '', description: 'Display name' },
+      },
+    });
+  });
+
+  it('does not mutate the input schema', () => {
+    const schema: oas31.SchemaObject = {
+      type: 'object',
+      properties: {
+        id: { type: 'string', readOnly: true },
+      },
+    };
+    const snapshot = JSON.stringify(schema);
+
+    stripReadOnly(schema);
+
+    expect(JSON.stringify(schema)).toBe(snapshot);
+  });
+
+  it('handles full File schema (regression test for issue #20)', () => {
+    const schema: oas31.SchemaObject = {
+      type: 'object',
+      additionalProperties: false,
+      required: [
+        'extension',
+        'fileId',
+        'fileName',
+        'hash',
+        'height',
+        'mimeType',
+        'size',
+        'status',
+        'url',
+        'width',
+      ],
+      properties: {
+        status: { type: 'string', default: '', readOnly: true },
+        fileId: { type: 'string', default: '', readOnly: true },
+        url: { type: 'string', default: '', readOnly: true },
+        fileName: { type: 'string', default: '' },
+        hash: { type: 'string', default: '', readOnly: true },
+        extension: { type: 'string', default: '', readOnly: true },
+        mimeType: { type: 'string', default: '', readOnly: true },
+        size: { type: 'number', default: 0, readOnly: true },
+        width: { type: 'number', default: 0, readOnly: true },
+        height: { type: 'number', default: 0, readOnly: true },
+      },
+    };
+
+    const result = stripReadOnly(schema);
+
+    const props = result.properties ?? {};
+    for (const key of Object.keys(props)) {
+      expect((props[key] as oas31.SchemaObject).readOnly).toBeUndefined();
+    }
+    expect(Object.keys(props).sort()).toEqual([
+      'extension',
+      'fileId',
+      'fileName',
+      'hash',
+      'height',
+      'mimeType',
+      'size',
+      'status',
+      'url',
+      'width',
+    ]);
+  });
+});

--- a/src/endpoint-microservice/restapi/queries/handlers/get-open-api-schema.handler.ts
+++ b/src/endpoint-microservice/restapi/queries/handlers/get-open-api-schema.handler.ts
@@ -14,6 +14,7 @@ import {
   createSingleRowPath,
   createTableInfoMap,
   getFilterAndSortSchemas,
+  stripReadOnly,
   TablePathInfo,
 } from './open-api-schema.utils';
 
@@ -104,9 +105,10 @@ export class GetOpenApiSchemaHandler implements IQueryHandler<GetOpenApiSchemaQu
 
       openApiJson.components ??= { schemas: {} };
       openApiJson.components.schemas ??= {};
-      openApiJson.components.schemas[info.schemaName] = resolveRefs(
-        schemaRow.data as JsonSchema,
-      );
+      const resolvedSchema = resolveRefs(schemaRow.data as JsonSchema);
+      openApiJson.components.schemas[info.schemaName] = resolvedSchema;
+      openApiJson.components.schemas[info.inputSchemaName] =
+        stripReadOnly(resolvedSchema);
     }
 
     return openApiJson;

--- a/src/endpoint-microservice/restapi/queries/handlers/open-api-schema.utils.ts
+++ b/src/endpoint-microservice/restapi/queries/handlers/open-api-schema.utils.ts
@@ -14,6 +14,7 @@ import {
 export interface TablePathInfo {
   rawTableId: string;
   schemaName: string;
+  inputSchemaName: string;
   tag: string;
 }
 
@@ -25,6 +26,70 @@ const getSchemaName = (tableId: string, projectName: string): string => {
   const name = capitalize(tableId);
   return `${prefix}${name}`;
 };
+
+const getInputSchemaName = (schemaName: string): string => `${schemaName}Input`;
+
+// Recursively returns a deep copy of the schema with `readOnly` markers
+// removed. Used to build separate write-side ("Input") schemas so Swagger UI
+// renders create/update example bodies with all fields present (e.g. the full
+// File metadata object the backend expects on row creation).
+export function stripReadOnly(schema: oas31.SchemaObject): oas31.SchemaObject;
+export function stripReadOnly(
+  schema: oas31.ReferenceObject,
+): oas31.ReferenceObject;
+export function stripReadOnly(
+  schema: oas31.SchemaObject | oas31.ReferenceObject,
+): oas31.SchemaObject | oas31.ReferenceObject;
+export function stripReadOnly(
+  schema: oas31.SchemaObject | oas31.ReferenceObject,
+): oas31.SchemaObject | oas31.ReferenceObject {
+  if ('$ref' in schema) {
+    return { ...schema };
+  }
+
+  const result: oas31.SchemaObject = {};
+
+  for (const [key, value] of Object.entries(schema)) {
+    if (key === 'readOnly') continue;
+
+    if (key === 'properties' && value && typeof value === 'object') {
+      const props: Record<string, oas31.SchemaObject | oas31.ReferenceObject> =
+        {};
+      for (const [propKey, propValue] of Object.entries(
+        value as Record<string, oas31.SchemaObject | oas31.ReferenceObject>,
+      )) {
+        props[propKey] = stripReadOnly(propValue);
+      }
+      result.properties = props;
+      continue;
+    }
+
+    if (
+      (key === 'items' || key === 'additionalProperties') &&
+      value &&
+      typeof value === 'object'
+    ) {
+      (result as Record<string, unknown>)[key] = stripReadOnly(
+        value as oas31.SchemaObject | oas31.ReferenceObject,
+      );
+      continue;
+    }
+
+    if (
+      (key === 'oneOf' || key === 'anyOf' || key === 'allOf') &&
+      Array.isArray(value)
+    ) {
+      (result as Record<string, unknown>)[key] = (
+        value as Array<oas31.SchemaObject | oas31.ReferenceObject>
+      ).map((entry) => stripReadOnly(entry));
+      continue;
+    }
+
+    (result as Record<string, unknown>)[key] = value;
+  }
+
+  return result;
+}
 
 const getCommonSchemaName = (name: string, projectName: string): string => {
   const prefix = capitalize(projectName);
@@ -464,6 +529,7 @@ export const createSingleRowPath = (
   isDraft: boolean,
 ): oas31.PathItemObject => {
   const schemaRef = `#/components/schemas/${info.schemaName}`;
+  const inputSchemaRef = `#/components/schemas/${info.inputSchemaName}`;
   const rowResponseSchema = getSingleRowResponseSchema(schemaRef);
   const patchOperationRef = `#/components/schemas/${getCommonSchemaName('PatchOperation', projectName)}`;
 
@@ -493,7 +559,7 @@ export const createSingleRowPath = (
             type: 'object',
             required: ['data'],
             properties: {
-              data: { $ref: schemaRef },
+              data: { $ref: inputSchemaRef },
             },
           },
         },
@@ -797,6 +863,7 @@ export const createBulkRowsPath = (
   projectName: string,
 ): oas31.PathItemObject => {
   const schemaRef = `#/components/schemas/${info.schemaName}`;
+  const inputSchemaRef = `#/components/schemas/${info.inputSchemaName}`;
   const patchOperationRef = `#/components/schemas/${getCommonSchemaName('PatchOperation', projectName)}`;
   const bulkResponseSchema = getBulkResponseSchema(schemaRef);
 
@@ -806,7 +873,7 @@ export const createBulkRowsPath = (
       verb: 'Creates',
       requestDescription: 'Array of rows to create',
       responseDescription: 'Created rows',
-      getRequestSchema: () => getBulkRowsRequestSchema(schemaRef),
+      getRequestSchema: () => getBulkRowsRequestSchema(inputSchemaRef),
       getResponseSchema: () => bulkResponseSchema,
     }),
     put: createBulkOperation(info, {
@@ -814,7 +881,7 @@ export const createBulkRowsPath = (
       verb: 'Updates',
       requestDescription: 'Array of rows to update',
       responseDescription: 'Updated rows',
-      getRequestSchema: () => getBulkRowsRequestSchema(schemaRef),
+      getRequestSchema: () => getBulkRowsRequestSchema(inputSchemaRef),
       getResponseSchema: () => bulkResponseSchema,
     }),
     patch: createBulkOperation(info, {
@@ -844,9 +911,11 @@ export const createTableInfoMap = (
   const map = new Map<string, TablePathInfo>();
 
   for (const rawTableId of tableIds) {
+    const schemaName = getSchemaName(rawTableId, projectName);
     map.set(rawTableId, {
       rawTableId,
-      schemaName: getSchemaName(rawTableId, projectName),
+      schemaName,
+      inputSchemaName: getInputSchemaName(schemaName),
       tag: rawTableId,
     });
   }


### PR DESCRIPTION
https://github.com/revisium/qa/issues/20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OpenAPI documentation now generates separate input and output schemas for all table operations, providing clearer API specifications for request and response payloads.
  * Create, update, and bulk operations now reference dedicated input schemas in request body definitions.

* **Tests**
  * Added comprehensive test coverage for input schema generation and read-only field handling in OpenAPI documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->