### PR TITLE
docs: clarify internal API key endpoint configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,9 +14,11 @@ The `@revisium/endpoint` service supports various environment variables for conf
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `CORE_API_URL` | **Required** | URL to the revisium-core API service |
-| `INTERNAL_API_KEY_ENDPOINT` | **Required in microservice mode** | Internal API key for endpoint-to-core authentication. Must match the value set on revisium-core and match `/^rev_[A-Za-z0-9_-]{22}$/` |
-| `CORE_API_URL_USERNAME` | - | Deprecated fallback username for core password authentication |
-| `CORE_API_URL_PASSWORD` | - | Deprecated fallback password for core password authentication |
+| `INTERNAL_API_KEY_ENDPOINT` | **Recommended (microservice mode)** | Preferred internal API key for endpoint-to-core authentication. Required for new deployments. Must match the value set on revisium-core and match `/^rev_[A-Za-z0-9_-]{22}$/` |
+| `CORE_API_URL_USERNAME` | - | Deprecated fallback username for core password authentication, used only when `INTERNAL_API_KEY_ENDPOINT` is absent |
+| `CORE_API_URL_PASSWORD` | - | Deprecated fallback password for core password authentication, used only when `INTERNAL_API_KEY_ENDPOINT` is absent |
+
+Authentication priority is `INTERNAL_API_KEY_ENDPOINT` first, then the deprecated `CORE_API_URL_USERNAME` / `CORE_API_URL_PASSWORD` fallback. New and upgraded microservice deployments should set `INTERNAL_API_KEY_ENDPOINT` and stop relying on password fallback credentials.
 
 ## Redis Microservice Configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,8 +14,9 @@ The `@revisium/endpoint` service supports various environment variables for conf
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `CORE_API_URL` | **Required** | URL to the revisium-core API service |
-| `CORE_API_URL_USERNAME` | **Required** | Username for core API authentication |
-| `CORE_API_URL_PASSWORD` | **Required** | Password for core API authentication |
+| `INTERNAL_API_KEY_ENDPOINT` | **Required in microservice mode** | Internal API key for endpoint-to-core authentication. Must match the value set on revisium-core and match `/^rev_[A-Za-z0-9_-]{22}$/` |
+| `CORE_API_URL_USERNAME` | - | Deprecated fallback username for core password authentication |
+| `CORE_API_URL_PASSWORD` | - | Deprecated fallback password for core password authentication |
 
 ## Redis Microservice Configuration
 

--- a/docs/core-integration.md
+++ b/docs/core-integration.md
@@ -14,24 +14,26 @@ Internal API Key is the recommended auth method. Stateless, no token refresh, no
 
 ### Setup
 
-1. Generate a key: `cd revisium-core && npm run generate:internal-key`
+1. Generate a key: `cd revisium-core && npm run generate:internal-key -- ENDPOINT`
 2. Set `INTERNAL_API_KEY_ENDPOINT` env var in both core and endpoint services (same value)
 3. Restart both services — core registers the key in DB, endpoint uses it as `X-Internal-Api-Key` header
+
+The key must match `/^rev_[A-Za-z0-9_-]{22}$/` (`rev_` plus 22 base64url/nanoid characters). Do not use plain `openssl rand -hex 32`; core rejects values that do not match this format.
 
 ### Multiple internal services
 
 Each internal service uses its own env var following the `INTERNAL_API_KEY_{SERVICE}` pattern:
 
 ```bash
-INTERNAL_API_KEY_ENDPOINT=rev_xxxxxxxxxxxxxxxxxxxx   # for endpoint service
-INTERNAL_API_KEY_WORKER=rev_yyyyyyyyyyyyyyyyyyyyyy   # for worker service
+INTERNAL_API_KEY_ENDPOINT=rev_ChangeMe0123456789abcd   # for endpoint service; example format only
+INTERNAL_API_KEY_WORKER=rev_ChangeMe0123456789abce     # for worker service; example format only
 ```
 
 Core registers each service as a separate DB record with `internalServiceName` derived from the suffix (lowercased). Keys are independent — rotating one does not affect others.
 
 ### Rotation
 
-1. Generate a new key: `npm run generate:internal-key`
+1. Generate a new key: `npm run generate:internal-key -- ENDPOINT`
 2. Update `INTERNAL_API_KEY_ENDPOINT` in both services
 3. Restart core first (registers new key, revokes old), then endpoint
 

--- a/docs/core-integration.md
+++ b/docs/core-integration.md
@@ -33,7 +33,7 @@ Core registers each service as a separate DB record with `internalServiceName` d
 
 ### Rotation
 
-1. Generate a new key: `npm run generate:internal-key -- ENDPOINT`
+1. Generate a new key: `cd revisium-core && npm run generate:internal-key -- ENDPOINT`
 2. Update `INTERNAL_API_KEY_ENDPOINT` in both services
 3. Restart core first (registers new key, revokes old), then endpoint
 

--- a/src/endpoint-microservice/core-api/__tests__/internal-core-api.service.spec.ts
+++ b/src/endpoint-microservice/core-api/__tests__/internal-core-api.service.spec.ts
@@ -29,7 +29,7 @@ describe('InternalCoreApiService', () => {
 
     beforeEach(() => {
       const configService = createMockConfigService({
-        INTERNAL_API_KEY_ENDPOINT: 'rev_test1234567890abcdef',
+        INTERNAL_API_KEY_ENDPOINT: 'rev_test1234567890abcdef12',
       });
       const prisma = createMockPrismaService();
       const options: AppOptions = { mode: 'monolith' };
@@ -53,7 +53,7 @@ describe('InternalCoreApiService', () => {
 
       expect(
         (params.headers as Record<string, string>)['X-Internal-Api-Key'],
-      ).toBe('rev_test1234567890abcdef');
+      ).toBe('rev_test1234567890abcdef12');
       expect(
         (params.headers as Record<string, string>)['Authorization'],
       ).toBeUndefined();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated microservice deployment docs to require key-based internal authentication for new deployments; legacy credential fields are now deprecated and used only as fallbacks.
  * Expanded guidance for key generation, validation, per-service setup, and rotation, including restart ordering for correct key registration and revocation.

* **Tests**
  * Adjusted authentication validation tests to reflect the new key format and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->