### PR TITLE
fix: avoid Redis health-check connection churn

### DIFF
--- a/src/endpoint-microservice/health/__tests__/notification.check.spec.ts
+++ b/src/endpoint-microservice/health/__tests__/notification.check.spec.ts
@@ -1,0 +1,209 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { HealthIndicatorService } from '@nestjs/terminus';
+import Redis from 'ioredis';
+import { NotificationCheck } from 'src/endpoint-microservice/health/notification.check';
+
+jest.mock('ioredis', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+describe('NotificationCheck', () => {
+  describe('available', () => {
+    it('should return true when Redis configuration is present', () => {
+      mockConfig();
+
+      expect(service.available).toBe(true);
+    });
+
+    it('should return false when Redis configuration is missing', () => {
+      (configService.get as jest.Mock).mockImplementation((key: string) => {
+        if (key === 'ENDPOINT_HOST') return '127.0.0.1';
+        return undefined;
+      });
+
+      expect(service.available).toBe(false);
+    });
+  });
+
+  describe('check', () => {
+    const PORT_KEY = 'ENDPOINT_PORT';
+    const HOST_KEY = 'ENDPOINT_HOST';
+
+    it('should throw if ENDPOINT_PORT env var is not set', async () => {
+      (configService.get as jest.Mock).mockImplementation((key: string) => {
+        if (key === PORT_KEY) return undefined;
+      });
+
+      await expect(service.check()).rejects.toThrow(
+        `Environment variable not found: ${PORT_KEY}`,
+      );
+    });
+
+    it('should throw if ENDPOINT_HOST env var is not set', async () => {
+      (configService.get as jest.Mock)
+        .mockImplementationOnce(() => '6379')
+        .mockImplementationOnce(() => undefined);
+
+      await expect(service.check()).rejects.toThrow(
+        `Environment variable not found: ${HOST_KEY}`,
+      );
+    });
+
+    it('should ping Redis and return an up result', async () => {
+      mockConfig();
+
+      const result = await service.check();
+
+      expect(RedisMock).toHaveBeenCalledWith({
+        host: '127.0.0.1',
+        port: 6380,
+        lazyConnect: true,
+        enableOfflineQueue: false,
+        maxRetriesPerRequest: 1,
+        connectTimeout: 1000,
+        retryStrategy: expect.any(Function),
+      });
+      expect(redisClient.connect).toHaveBeenCalledTimes(1);
+      expect(redisClient.ping).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ notification: { status: 'up' } });
+    });
+
+    it('should reuse the Redis client across checks', async () => {
+      mockConfig();
+      redisClient.connect.mockImplementation(async () => {
+        redisClient.status = 'ready';
+      });
+
+      await service.check();
+      await service.check();
+
+      expect(RedisMock).toHaveBeenCalledTimes(1);
+      expect(redisClient.connect).toHaveBeenCalledTimes(1);
+      expect(redisClient.ping).toHaveBeenCalledTimes(2);
+    });
+
+    it('should wait for an in-flight Redis connection before concurrent pings', async () => {
+      mockConfig();
+
+      let resolveConnect: () => void;
+      const connectPromise = new Promise<void>((resolve) => {
+        resolveConnect = () => {
+          redisClient.status = 'ready';
+          resolve();
+        };
+      });
+
+      redisClient.connect.mockReturnValue(connectPromise);
+      redisClient.ping.mockImplementation(async () => {
+        if (redisClient.status !== 'ready') {
+          throw new Error('Redis is not ready');
+        }
+        return 'PONG';
+      });
+
+      const firstCheck = service.check();
+      await Promise.resolve();
+
+      redisClient.status = 'connecting';
+
+      const secondCheck = service.check();
+      await Promise.resolve();
+
+      expect(redisClient.connect).toHaveBeenCalledTimes(1);
+      expect(redisClient.ping).not.toHaveBeenCalled();
+
+      resolveConnect!();
+
+      await expect(Promise.all([firstCheck, secondCheck])).resolves.toEqual([
+        { notification: { status: 'up' } },
+        { notification: { status: 'up' } },
+      ]);
+      expect(redisClient.ping).toHaveBeenCalledTimes(2);
+    });
+
+    it('should return a down result when Redis ping fails', async () => {
+      mockConfig();
+      redisClient.ping.mockRejectedValue(new Error('Redis unavailable'));
+
+      const result = await service.check();
+
+      expect(result).toEqual({
+        notification: {
+          status: 'down',
+          message: 'Redis unavailable',
+        },
+      });
+    });
+
+    it('should close the Redis client on module destroy', async () => {
+      mockConfig();
+      await service.check();
+
+      await service.onModuleDestroy();
+
+      expect(redisClient.quit).toHaveBeenCalledTimes(1);
+      expect(redisClient.disconnect).not.toHaveBeenCalled();
+    });
+
+    it('should disconnect the Redis client if graceful quit fails', async () => {
+      mockConfig();
+      redisClient.quit.mockRejectedValue(new Error('quit failed'));
+      await service.check();
+
+      await service.onModuleDestroy();
+
+      expect(redisClient.disconnect).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  let service: NotificationCheck;
+  let configService: Partial<ConfigService>;
+  let healthIndicator: HealthIndicatorService;
+  let redisClient: {
+    status: string;
+    connect: jest.Mock<Promise<void>, []>;
+    ping: jest.Mock<Promise<string>, []>;
+    quit: jest.Mock<Promise<string>, []>;
+    disconnect: jest.Mock<void, []>;
+    on: jest.Mock;
+  };
+
+  const RedisMock = Redis as unknown as jest.Mock;
+
+  beforeEach(async () => {
+    configService = {
+      get: jest.fn(),
+    };
+    healthIndicator = new HealthIndicatorService();
+    redisClient = {
+      status: 'wait',
+      connect: jest.fn().mockResolvedValue(undefined),
+      ping: jest.fn().mockResolvedValue('PONG'),
+      quit: jest.fn().mockResolvedValue('OK'),
+      disconnect: jest.fn(),
+      on: jest.fn(),
+    };
+    RedisMock.mockClear();
+    RedisMock.mockImplementation(() => redisClient);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationCheck,
+        { provide: ConfigService, useValue: configService },
+        { provide: HealthIndicatorService, useValue: healthIndicator },
+      ],
+    }).compile();
+
+    service = module.get<NotificationCheck>(NotificationCheck);
+  });
+
+  function mockConfig() {
+    (configService.get as jest.Mock).mockImplementation((key: string) => {
+      if (key === 'ENDPOINT_PORT') return '6380';
+      if (key === 'ENDPOINT_HOST') return '127.0.0.1';
+      return undefined;
+    });
+  }
+});

--- a/src/endpoint-microservice/health/health.controller.ts
+++ b/src/endpoint-microservice/health/health.controller.ts
@@ -22,9 +22,12 @@ export class HealthController {
   liveness() {
     const indicators: HealthIndicatorFunction[] = [
       async () => this.prisma.check(),
-      async () => this.notifications.check(),
       async () => this.coreApi.check(),
     ];
+
+    if (this.notifications.available) {
+      indicators.push(async () => this.notifications.check());
+    }
 
     return this.health.check(indicators);
   }

--- a/src/endpoint-microservice/health/notification.check.ts
+++ b/src/endpoint-microservice/health/notification.check.ts
@@ -1,16 +1,56 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { Transport, RedisOptions } from '@nestjs/microservices';
-import { MicroserviceHealthIndicator } from '@nestjs/terminus';
+import { HealthIndicatorService } from '@nestjs/terminus';
+import Redis from 'ioredis';
 
 @Injectable()
-export class NotificationCheck {
+export class NotificationCheck implements OnModuleDestroy {
+  private redis?: Redis;
+  private connectPromise?: Promise<void>;
+
   constructor(
     private readonly configService: ConfigService,
-    private readonly microservice: MicroserviceHealthIndicator,
+    private readonly healthIndicator: HealthIndicatorService,
   ) {}
 
+  public get available() {
+    return this.hasRedisConfiguration();
+  }
+
   public async check() {
+    const indicator = this.healthIndicator.check('notification');
+    const redis = this.getRedis();
+
+    try {
+      await this.ensureConnected(redis);
+      await redis.ping();
+      return indicator.up();
+    } catch (error) {
+      return indicator.down(
+        error instanceof Error
+          ? error.message
+          : 'Redis notification bus is not available',
+      );
+    }
+  }
+
+  public async onModuleDestroy() {
+    if (!this.redis) {
+      return;
+    }
+
+    try {
+      await this.redis.quit();
+    } catch {
+      this.redis.disconnect();
+    }
+  }
+
+  private getRedis() {
+    if (this.redis) {
+      return this.redis;
+    }
+
     const portPath = 'ENDPOINT_PORT';
     const hostPath = 'ENDPOINT_HOST';
 
@@ -27,12 +67,45 @@ export class NotificationCheck {
       throw new Error(`Environment variable not found: ${hostPath}`);
     }
 
-    return this.microservice.pingCheck<RedisOptions>('notification', {
-      transport: Transport.REDIS,
-      options: {
-        host,
-        port,
-      },
+    this.redis = new Redis({
+      host,
+      port,
+      lazyConnect: true,
+      enableOfflineQueue: false,
+      maxRetriesPerRequest: 1,
+      connectTimeout: 1000,
+      retryStrategy: (times) => Math.min(times * 100, 1000),
     });
+    this.redis.on('error', () => undefined);
+
+    return this.redis;
+  }
+
+  private hasRedisConfiguration() {
+    return Boolean(
+      this.configService.get<string>('ENDPOINT_HOST') &&
+      this.configService.get<string>('ENDPOINT_PORT'),
+    );
+  }
+
+  private async ensureConnected(redis: Redis) {
+    if (redis.status === 'ready') {
+      return;
+    }
+
+    if (this.connectPromise) {
+      await this.connectPromise;
+      return;
+    }
+
+    if (redis.status !== 'wait' && redis.status !== 'end') {
+      return;
+    }
+
+    this.connectPromise = redis.connect().finally(() => {
+      this.connectPromise = undefined;
+    });
+
+    await this.connectPromise;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests covering notification health checks, connection reuse, failure reporting, and graceful shutdown behavior.

* **Refactor**
  * Notification health check now performs direct connectivity checks to the notification backend, reports up/down status with error details, reuses the client across checks, conditionally enables itself when endpoint is configured, and ensures graceful shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->