### PR TITLE
fix: generate write input schemas for OpenAPI row writes

### DIFF
--- a/src/endpoint-microservice/restapi/__tests__/restapi-openapi-file-input.spec.ts
+++ b/src/endpoint-microservice/restapi/__tests__/restapi-openapi-file-input.spec.ts
@@ -1,0 +1,247 @@
+import { INestApplication } from '@nestjs/common';
+import { QueryBus } from '@nestjs/cqrs';
+import { Test, TestingModule } from '@nestjs/testing';
+import { oas31 } from 'openapi3-ts';
+import {
+  getArraySchema,
+  getObjectSchema,
+  getRefSchema,
+  getStringSchema,
+} from '@revisium/schema-toolkit/mocks';
+import { SystemSchemaIds } from '@revisium/schema-toolkit/consts';
+import { InternalCoreApiService } from 'src/endpoint-microservice/core-api/internal-core-api.service';
+import { ProxyCoreApiService } from 'src/endpoint-microservice/core-api/proxy-core-api.service';
+import { PrismaService } from 'src/endpoint-microservice/database/prisma.service';
+import { EndpointMicroserviceModule } from 'src/endpoint-microservice/endpoint-microservice.module';
+import { GetOpenApiSchemaQuery } from 'src/endpoint-microservice/restapi/queries/impl';
+import { OpenApiSchema } from 'src/endpoint-microservice/shared/types/open-api-schema';
+import { SystemTables } from 'src/endpoint-microservice/shared/system-tables.consts';
+
+const REVISION_ID = 'rev-1';
+const PROJECT_NAME = 'TestProject';
+const TABLE_ID = 'document';
+const SCHEMA_NAME = 'TestProjectDocument';
+const WRITE_SCHEMA_NAME = 'TestProjectDocumentWriteInput';
+
+const WRITABLE_FILE_FIELDS = ['fileName'];
+const SERVER_MANAGED_FILE_FIELDS = [
+  'status',
+  'fileId',
+  'url',
+  'hash',
+  'extension',
+  'mimeType',
+  'size',
+  'width',
+  'height',
+];
+
+const createSchemaTableData = () => ({
+  data: {
+    edges: [
+      {
+        node: {
+          id: TABLE_ID,
+          data: getObjectSchema({
+            title: getStringSchema(),
+            file: getRefSchema(SystemSchemaIds.File),
+            nested: getObjectSchema({
+              contract: getRefSchema(SystemSchemaIds.File),
+            }),
+            gallery: getArraySchema(getRefSchema(SystemSchemaIds.File)),
+          }),
+        },
+      },
+    ],
+    totalCount: 1,
+  },
+  error: null,
+});
+
+const createMockInternalCoreApiService = () => ({
+  initApi: jest.fn().mockResolvedValue(undefined),
+  api: {
+    login: jest.fn().mockResolvedValue({
+      data: { accessToken: 'mock-token' },
+      error: null,
+    }),
+    rows: jest
+      .fn()
+      .mockImplementation((_revisionId: string, tableId: string) => {
+        if (tableId === SystemTables.Schema) {
+          return Promise.resolve(createSchemaTableData());
+        }
+        return Promise.resolve({
+          data: { edges: [], totalCount: 0 },
+          error: null,
+        });
+      }),
+    revision: jest.fn().mockResolvedValue({
+      data: { isDraft: true },
+      error: null,
+    }),
+    tableForeignKeysBy: jest.fn().mockResolvedValue({
+      data: { edges: [] },
+      error: null,
+    }),
+    endpoints: jest.fn().mockResolvedValue({
+      data: { edges: [], totalCount: 0 },
+      error: null,
+    }),
+  },
+});
+
+const createMockProxyCoreApiService = () => ({ api: {} });
+
+const createMockPrismaService = () => ({
+  endpoint: { findMany: jest.fn().mockResolvedValue([]) },
+});
+
+type JsonContentObject = {
+  content?: Record<
+    string,
+    {
+      schema?: oas31.SchemaObject | oas31.ReferenceObject;
+    }
+  >;
+};
+
+const getJsonSchema = (body: unknown) =>
+  (body as JsonContentObject | undefined)?.content?.['application/json']
+    ?.schema as oas31.SchemaObject;
+
+const getDataRef = (schema: oas31.SchemaObject | undefined) =>
+  (schema?.properties?.data as oas31.ReferenceObject | undefined)?.$ref;
+
+const getBulkDataRef = (schema: oas31.SchemaObject | undefined) => {
+  const rows = schema?.properties?.rows as oas31.SchemaObject | undefined;
+  const items = rows?.items as oas31.SchemaObject | undefined;
+  return (items?.properties?.data as oas31.ReferenceObject | undefined)?.$ref;
+};
+
+describe('OpenAPI write schemas for File fields (qa#20)', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  let app: INestApplication;
+  let queryBus: QueryBus;
+  let openApiJson: OpenApiSchema;
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [EndpointMicroserviceModule.forRoot({ mode: 'monolith' })],
+    })
+      .overrideProvider(InternalCoreApiService)
+      .useValue(createMockInternalCoreApiService())
+      .overrideProvider(ProxyCoreApiService)
+      .useValue(createMockProxyCoreApiService())
+      .overrideProvider(PrismaService)
+      .useValue(createMockPrismaService())
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    queryBus = app.get(QueryBus);
+    openApiJson = await queryBus.execute<GetOpenApiSchemaQuery, OpenApiSchema>(
+      new GetOpenApiSchemaQuery({
+        revisionId: REVISION_ID,
+        projectName: PROJECT_NAME,
+      }),
+    );
+  });
+
+  afterAll(async () => {
+    process.env.NODE_ENV = originalNodeEnv;
+    await app.close();
+  }, 10000);
+
+  it('creates output and write input schemas', () => {
+    const schemas = openApiJson.components?.schemas ?? {};
+    expect(schemas).toHaveProperty(SCHEMA_NAME);
+    expect(schemas).toHaveProperty(WRITE_SCHEMA_NAME);
+  });
+
+  it('uses write input schema for single create and update request bodies', () => {
+    const path = openApiJson.paths?.[`/tables/${TABLE_ID}/row/{rowId}`];
+
+    expect(getDataRef(getJsonSchema(path?.post?.requestBody))).toBe(
+      `#/components/schemas/${WRITE_SCHEMA_NAME}`,
+    );
+    expect(getDataRef(getJsonSchema(path?.put?.requestBody))).toBe(
+      `#/components/schemas/${WRITE_SCHEMA_NAME}`,
+    );
+  });
+
+  it('uses write input schema for bulk create and update request bodies', () => {
+    const path = openApiJson.paths?.[`/tables/${TABLE_ID}/rows/bulk`];
+
+    expect(getBulkDataRef(getJsonSchema(path?.post?.requestBody))).toBe(
+      `#/components/schemas/${WRITE_SCHEMA_NAME}`,
+    );
+    expect(getBulkDataRef(getJsonSchema(path?.put?.requestBody))).toBe(
+      `#/components/schemas/${WRITE_SCHEMA_NAME}`,
+    );
+  });
+
+  it('keeps response schemas on the output schema', () => {
+    const singlePath = openApiJson.paths?.[`/tables/${TABLE_ID}/row/{rowId}`];
+    const rowsPath = openApiJson.paths?.[`/tables/${TABLE_ID}/rows`];
+
+    expect(getDataRef(getJsonSchema(singlePath?.get?.responses?.['200']))).toBe(
+      `#/components/schemas/${SCHEMA_NAME}`,
+    );
+    expect(
+      getDataRef(getJsonSchema(singlePath?.post?.responses?.['200'])),
+    ).toBe(`#/components/schemas/${SCHEMA_NAME}`);
+
+    const listResponseSchema = getJsonSchema(
+      rowsPath?.post?.responses?.['200'],
+    );
+    const edges = listResponseSchema?.properties?.edges as
+      | oas31.SchemaObject
+      | undefined;
+    const edge = edges?.items as oas31.SchemaObject | undefined;
+    const node = edge?.properties?.node as oas31.SchemaObject | undefined;
+    expect(getDataRef(node)).toBe(`#/components/schemas/${SCHEMA_NAME}`);
+  });
+
+  it('keeps file metadata in output schema', () => {
+    const outputSchema = openApiJson.components?.schemas?.[
+      SCHEMA_NAME
+    ] as oas31.SchemaObject;
+    const file = outputSchema.properties?.file as oas31.SchemaObject;
+
+    for (const field of [...SERVER_MANAGED_FILE_FIELDS, 'fileName']) {
+      expect(file.properties).toHaveProperty(field);
+    }
+
+    for (const field of SERVER_MANAGED_FILE_FIELDS) {
+      expect((file.properties?.[field] as oas31.SchemaObject).readOnly).toBe(
+        true,
+      );
+    }
+  });
+
+  it('omits server-managed file metadata from write input schema', () => {
+    const writeSchema = openApiJson.components?.schemas?.[
+      WRITE_SCHEMA_NAME
+    ] as oas31.SchemaObject;
+    const file = writeSchema.properties?.file as oas31.SchemaObject;
+    const nested = writeSchema.properties?.nested as oas31.SchemaObject;
+    const contract = nested.properties?.contract as oas31.SchemaObject;
+    const gallery = writeSchema.properties?.gallery as oas31.SchemaObject;
+    const galleryItem = gallery.items as oas31.SchemaObject;
+
+    for (const fileSchema of [file, contract, galleryItem]) {
+      expect(Object.keys(fileSchema.properties ?? {}).sort()).toEqual(
+        WRITABLE_FILE_FIELDS,
+      );
+      expect(fileSchema.required).toEqual(WRITABLE_FILE_FIELDS);
+
+      for (const field of SERVER_MANAGED_FILE_FIELDS) {
+        expect(fileSchema.properties).not.toHaveProperty(field);
+      }
+    }
+  });
+});

--- a/src/endpoint-microservice/restapi/__tests__/restapi-openapi-file-input.spec.ts
+++ b/src/endpoint-microservice/restapi/__tests__/restapi-openapi-file-input.spec.ts
@@ -121,7 +121,7 @@ const getBulkDataRef = (schema: oas31.SchemaObject | undefined) => {
 
 describe('OpenAPI write schemas for File fields (qa#20)', () => {
   const originalNodeEnv = process.env.NODE_ENV;
-  let app: INestApplication;
+  let app: INestApplication | undefined;
   let queryBus: QueryBus;
   let openApiJson: OpenApiSchema;
 
@@ -153,7 +153,7 @@ describe('OpenAPI write schemas for File fields (qa#20)', () => {
 
   afterAll(async () => {
     process.env.NODE_ENV = originalNodeEnv;
-    await app.close();
+    await app?.close();
   }, 10000);
 
   it('creates output and write input schemas', () => {

--- a/src/endpoint-microservice/restapi/__tests__/snapshots/complex-schema.openapi.json
+++ b/src/endpoint-microservice/restapi/__tests__/snapshots/complex-schema.openapi.json
@@ -336,7 +336,7 @@
                 ],
                 "properties": {
                   "data": {
-                    "$ref": "#/components/schemas/TestProjectAuthor"
+                    "$ref": "#/components/schemas/TestProjectAuthorWriteInput"
                   }
                 }
               }
@@ -446,7 +446,7 @@
                 ],
                 "properties": {
                   "data": {
-                    "$ref": "#/components/schemas/TestProjectAuthor"
+                    "$ref": "#/components/schemas/TestProjectAuthorWriteInput"
                   }
                 }
               }
@@ -815,7 +815,7 @@
                           "description": "Unique row identifier"
                         },
                         "data": {
-                          "$ref": "#/components/schemas/TestProjectAuthor",
+                          "$ref": "#/components/schemas/TestProjectAuthorWriteInput",
                           "description": "Row data"
                         }
                       }
@@ -953,7 +953,7 @@
                           "description": "Unique row identifier"
                         },
                         "data": {
-                          "$ref": "#/components/schemas/TestProjectAuthor",
+                          "$ref": "#/components/schemas/TestProjectAuthorWriteInput",
                           "description": "Row data"
                         }
                       }
@@ -1721,7 +1721,7 @@
                 ],
                 "properties": {
                   "data": {
-                    "$ref": "#/components/schemas/TestProjectCategory"
+                    "$ref": "#/components/schemas/TestProjectCategoryWriteInput"
                   }
                 }
               }
@@ -1831,7 +1831,7 @@
                 ],
                 "properties": {
                   "data": {
-                    "$ref": "#/components/schemas/TestProjectCategory"
+                    "$ref": "#/components/schemas/TestProjectCategoryWriteInput"
                   }
                 }
               }
@@ -2200,7 +2200,7 @@
                           "description": "Unique row identifier"
                         },
                         "data": {
-                          "$ref": "#/components/schemas/TestProjectCategory",
+                          "$ref": "#/components/schemas/TestProjectCategoryWriteInput",
                           "description": "Row data"
                         }
                       }
@@ -2338,7 +2338,7 @@
                           "description": "Unique row identifier"
                         },
                         "data": {
-                          "$ref": "#/components/schemas/TestProjectCategory",
+                          "$ref": "#/components/schemas/TestProjectCategoryWriteInput",
                           "description": "Row data"
                         }
                       }
@@ -3277,7 +3277,7 @@
                 ],
                 "properties": {
                   "data": {
-                    "$ref": "#/components/schemas/TestProjectMedia"
+                    "$ref": "#/components/schemas/TestProjectMediaWriteInput"
                   }
                 }
               }
@@ -3387,7 +3387,7 @@
                 ],
                 "properties": {
                   "data": {
-                    "$ref": "#/components/schemas/TestProjectMedia"
+                    "$ref": "#/components/schemas/TestProjectMediaWriteInput"
                   }
                 }
               }
@@ -3756,7 +3756,7 @@
                           "description": "Unique row identifier"
                         },
                         "data": {
-                          "$ref": "#/components/schemas/TestProjectMedia",
+                          "$ref": "#/components/schemas/TestProjectMediaWriteInput",
                           "description": "Row data"
                         }
                       }
@@ -3894,7 +3894,7 @@
                           "description": "Unique row identifier"
                         },
                         "data": {
-                          "$ref": "#/components/schemas/TestProjectMedia",
+                          "$ref": "#/components/schemas/TestProjectMediaWriteInput",
                           "description": "Row data"
                         }
                       }
@@ -4491,7 +4491,7 @@
                 ],
                 "properties": {
                   "data": {
-                    "$ref": "#/components/schemas/TestProjectPost"
+                    "$ref": "#/components/schemas/TestProjectPostWriteInput"
                   }
                 }
               }
@@ -4601,7 +4601,7 @@
                 ],
                 "properties": {
                   "data": {
-                    "$ref": "#/components/schemas/TestProjectPost"
+                    "$ref": "#/components/schemas/TestProjectPostWriteInput"
                   }
                 }
               }
@@ -4970,7 +4970,7 @@
                           "description": "Unique row identifier"
                         },
                         "data": {
-                          "$ref": "#/components/schemas/TestProjectPost",
+                          "$ref": "#/components/schemas/TestProjectPostWriteInput",
                           "description": "Row data"
                         }
                       }
@@ -5108,7 +5108,7 @@
                           "description": "Unique row identifier"
                         },
                         "data": {
-                          "$ref": "#/components/schemas/TestProjectPost",
+                          "$ref": "#/components/schemas/TestProjectPostWriteInput",
                           "description": "Row data"
                         }
                       }
@@ -5705,7 +5705,7 @@
                 ],
                 "properties": {
                   "data": {
-                    "$ref": "#/components/schemas/TestProjectSettings"
+                    "$ref": "#/components/schemas/TestProjectSettingsWriteInput"
                   }
                 }
               }
@@ -5815,7 +5815,7 @@
                 ],
                 "properties": {
                   "data": {
-                    "$ref": "#/components/schemas/TestProjectSettings"
+                    "$ref": "#/components/schemas/TestProjectSettingsWriteInput"
                   }
                 }
               }
@@ -6184,7 +6184,7 @@
                           "description": "Unique row identifier"
                         },
                         "data": {
-                          "$ref": "#/components/schemas/TestProjectSettings",
+                          "$ref": "#/components/schemas/TestProjectSettingsWriteInput",
                           "description": "Row data"
                         }
                       }
@@ -6322,7 +6322,7 @@
                           "description": "Unique row identifier"
                         },
                         "data": {
-                          "$ref": "#/components/schemas/TestProjectSettings",
+                          "$ref": "#/components/schemas/TestProjectSettingsWriteInput",
                           "description": "Row data"
                         }
                       }
@@ -6919,7 +6919,7 @@
                 ],
                 "properties": {
                   "data": {
-                    "$ref": "#/components/schemas/TestProjectTag"
+                    "$ref": "#/components/schemas/TestProjectTagWriteInput"
                   }
                 }
               }
@@ -7029,7 +7029,7 @@
                 ],
                 "properties": {
                   "data": {
-                    "$ref": "#/components/schemas/TestProjectTag"
+                    "$ref": "#/components/schemas/TestProjectTagWriteInput"
                   }
                 }
               }
@@ -7398,7 +7398,7 @@
                           "description": "Unique row identifier"
                         },
                         "data": {
-                          "$ref": "#/components/schemas/TestProjectTag",
+                          "$ref": "#/components/schemas/TestProjectTagWriteInput",
                           "description": "Row data"
                         }
                       }
@@ -7536,7 +7536,7 @@
                           "description": "Unique row identifier"
                         },
                         "data": {
-                          "$ref": "#/components/schemas/TestProjectTag",
+                          "$ref": "#/components/schemas/TestProjectTagWriteInput",
                           "description": "Row data"
                         }
                       }
@@ -8505,7 +8505,115 @@
           }
         }
       },
+      "TestProjectAuthorWriteInput": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "age",
+          "avatar",
+          "bio",
+          "email",
+          "isVerified",
+          "name",
+          "socialLinks"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "default": ""
+          },
+          "email": {
+            "type": "string",
+            "default": ""
+          },
+          "bio": {
+            "type": "string",
+            "default": ""
+          },
+          "age": {
+            "type": "number",
+            "default": 0
+          },
+          "isVerified": {
+            "type": "boolean",
+            "default": false
+          },
+          "avatar": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "fileName"
+            ],
+            "properties": {
+              "fileName": {
+                "type": "string",
+                "default": ""
+              }
+            }
+          },
+          "socialLinks": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "platform",
+                "url"
+              ],
+              "properties": {
+                "platform": {
+                  "type": "string",
+                  "default": ""
+                },
+                "url": {
+                  "type": "string",
+                  "default": ""
+                }
+              }
+            }
+          }
+        }
+      },
       "TestProjectCategory": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "description",
+          "isActive",
+          "name",
+          "order",
+          "parent",
+          "slug"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "default": ""
+          },
+          "slug": {
+            "type": "string",
+            "default": ""
+          },
+          "description": {
+            "type": "string",
+            "default": ""
+          },
+          "parent": {
+            "type": "string",
+            "default": "",
+            "foreignKey": "category"
+          },
+          "order": {
+            "type": "number",
+            "default": 0
+          },
+          "isActive": {
+            "type": "boolean",
+            "default": false
+          }
+        }
+      },
+      "TestProjectCategoryWriteInput": {
         "type": "object",
         "additionalProperties": false,
         "required": [
@@ -8619,6 +8727,62 @@
                 "type": "number",
                 "default": 0,
                 "readOnly": true
+              }
+            }
+          },
+          "alt": {
+            "type": "string",
+            "default": ""
+          },
+          "caption": {
+            "type": "string",
+            "default": ""
+          },
+          "type": {
+            "type": "string",
+            "default": ""
+          },
+          "dimensions": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "height",
+              "width"
+            ],
+            "properties": {
+              "width": {
+                "type": "number",
+                "default": 0
+              },
+              "height": {
+                "type": "number",
+                "default": 0
+              }
+            }
+          }
+        }
+      },
+      "TestProjectMediaWriteInput": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "alt",
+          "caption",
+          "dimensions",
+          "file",
+          "type"
+        ],
+        "properties": {
+          "file": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "fileName"
+            ],
+            "properties": {
+              "fileName": {
+                "type": "string",
+                "default": ""
               }
             }
           },
@@ -8952,6 +9116,196 @@
           }
         }
       },
+      "TestProjectPostWriteInput": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "author",
+          "category",
+          "comments",
+          "content",
+          "excerpt",
+          "featuredImage",
+          "gallery",
+          "isPublished",
+          "metadata",
+          "publishedAt",
+          "slug",
+          "tags",
+          "title",
+          "viewCount"
+        ],
+        "properties": {
+          "title": {
+            "type": "string",
+            "default": ""
+          },
+          "slug": {
+            "type": "string",
+            "default": ""
+          },
+          "content": {
+            "type": "string",
+            "default": ""
+          },
+          "excerpt": {
+            "type": "string",
+            "default": ""
+          },
+          "author": {
+            "type": "string",
+            "default": "",
+            "foreignKey": "author"
+          },
+          "category": {
+            "type": "string",
+            "default": "",
+            "foreignKey": "category"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": "",
+              "foreignKey": "tag"
+            }
+          },
+          "featuredImage": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "fileName"
+            ],
+            "properties": {
+              "fileName": {
+                "type": "string",
+                "default": ""
+              }
+            }
+          },
+          "gallery": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "fileName"
+              ],
+              "properties": {
+                "fileName": {
+                  "type": "string",
+                  "default": ""
+                }
+              }
+            }
+          },
+          "publishedAt": {
+            "type": "string",
+            "default": ""
+          },
+          "viewCount": {
+            "type": "number",
+            "default": 0
+          },
+          "isPublished": {
+            "type": "boolean",
+            "default": false
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "customFields",
+              "keywords",
+              "seoDescription",
+              "seoTitle"
+            ],
+            "properties": {
+              "seoTitle": {
+                "type": "string",
+                "default": ""
+              },
+              "seoDescription": {
+                "type": "string",
+                "default": ""
+              },
+              "keywords": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "default": ""
+                }
+              },
+              "customFields": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "field1",
+                  "field2"
+                ],
+                "properties": {
+                  "field1": {
+                    "type": "string",
+                    "default": ""
+                  },
+                  "field2": {
+                    "type": "number",
+                    "default": 0
+                  }
+                }
+              }
+            }
+          },
+          "comments": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "authorName",
+                "content",
+                "createdAt",
+                "replies"
+              ],
+              "properties": {
+                "authorName": {
+                  "type": "string",
+                  "default": ""
+                },
+                "content": {
+                  "type": "string",
+                  "default": ""
+                },
+                "createdAt": {
+                  "type": "string",
+                  "default": ""
+                },
+                "replies": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "authorName",
+                      "content"
+                    ],
+                    "properties": {
+                      "authorName": {
+                        "type": "string",
+                        "default": ""
+                      },
+                      "content": {
+                        "type": "string",
+                        "default": ""
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "TestProjectSettings": {
         "type": "object",
         "additionalProperties": false,
@@ -9105,7 +9459,124 @@
           }
         }
       },
+      "TestProjectSettingsWriteInput": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "features",
+          "limits",
+          "logo",
+          "siteName",
+          "siteUrl",
+          "socialMedia"
+        ],
+        "properties": {
+          "siteName": {
+            "type": "string",
+            "default": ""
+          },
+          "siteUrl": {
+            "type": "string",
+            "default": ""
+          },
+          "logo": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "fileName"
+            ],
+            "properties": {
+              "fileName": {
+                "type": "string",
+                "default": ""
+              }
+            }
+          },
+          "socialMedia": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "facebook",
+              "instagram",
+              "twitter"
+            ],
+            "properties": {
+              "twitter": {
+                "type": "string",
+                "default": ""
+              },
+              "facebook": {
+                "type": "string",
+                "default": ""
+              },
+              "instagram": {
+                "type": "string",
+                "default": ""
+              }
+            }
+          },
+          "features": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "enableComments",
+              "enableNewsletter",
+              "maintenanceMode"
+            ],
+            "properties": {
+              "enableComments": {
+                "type": "boolean",
+                "default": false
+              },
+              "enableNewsletter": {
+                "type": "boolean",
+                "default": false
+              },
+              "maintenanceMode": {
+                "type": "boolean",
+                "default": false
+              }
+            }
+          },
+          "limits": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "maxUploadSize",
+              "postsPerPage"
+            ],
+            "properties": {
+              "maxUploadSize": {
+                "type": "number",
+                "default": 0
+              },
+              "postsPerPage": {
+                "type": "number",
+                "default": 0
+              }
+            }
+          }
+        }
+      },
       "TestProjectTag": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "color",
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "default": ""
+          },
+          "color": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      },
+      "TestProjectTagWriteInput": {
         "type": "object",
         "additionalProperties": false,
         "required": [

--- a/src/endpoint-microservice/restapi/queries/handlers/__tests__/open-api-schema.utils.spec.ts
+++ b/src/endpoint-microservice/restapi/queries/handlers/__tests__/open-api-schema.utils.spec.ts
@@ -1,0 +1,195 @@
+import { oas31 } from 'openapi3-ts';
+import { toWriteSchema } from '../open-api-schema.utils';
+
+describe('toWriteSchema', () => {
+  it('omits readOnly properties and removes them from required', () => {
+    const schema: oas31.SchemaObject = {
+      type: 'object',
+      required: ['id', 'name'],
+      properties: {
+        id: { type: 'string', readOnly: true },
+        name: { type: 'string', default: '' },
+      },
+    };
+
+    expect(toWriteSchema(schema)).toEqual({
+      type: 'object',
+      required: ['name'],
+      properties: {
+        name: { type: 'string', default: '' },
+      },
+    });
+  });
+
+  it('recurses into nested object properties', () => {
+    const schema: oas31.SchemaObject = {
+      type: 'object',
+      required: ['profile'],
+      properties: {
+        profile: {
+          type: 'object',
+          required: ['fileId', 'fileName'],
+          properties: {
+            fileId: { type: 'string', default: '', readOnly: true },
+            fileName: { type: 'string', default: '' },
+          },
+        },
+      },
+    };
+
+    expect(toWriteSchema(schema)).toEqual({
+      type: 'object',
+      required: ['profile'],
+      properties: {
+        profile: {
+          type: 'object',
+          required: ['fileName'],
+          properties: {
+            fileName: { type: 'string', default: '' },
+          },
+        },
+      },
+    });
+  });
+
+  it('recurses into array items', () => {
+    const schema: oas31.SchemaObject = {
+      type: 'object',
+      properties: {
+        files: {
+          type: 'array',
+          items: {
+            type: 'object',
+            required: ['status', 'fileName'],
+            properties: {
+              status: { type: 'string', default: '', readOnly: true },
+              fileName: { type: 'string', default: '' },
+            },
+          },
+        },
+      },
+    };
+
+    expect(toWriteSchema(schema)).toEqual({
+      type: 'object',
+      properties: {
+        files: {
+          type: 'array',
+          items: {
+            type: 'object',
+            required: ['fileName'],
+            properties: {
+              fileName: { type: 'string', default: '' },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('recurses into additionalProperties schemas', () => {
+    const schema: oas31.SchemaObject = {
+      type: 'object',
+      additionalProperties: {
+        type: 'object',
+        required: ['id', 'label'],
+        properties: {
+          id: { type: 'string', readOnly: true },
+          label: { type: 'string' },
+        },
+      },
+    };
+
+    expect(toWriteSchema(schema)).toEqual({
+      type: 'object',
+      additionalProperties: {
+        type: 'object',
+        required: ['label'],
+        properties: {
+          label: { type: 'string' },
+        },
+      },
+    });
+  });
+
+  it('recurses into oneOf, anyOf, and allOf schemas', () => {
+    const schema: oas31.SchemaObject = {
+      oneOf: [
+        {
+          type: 'object',
+          required: ['id', 'name'],
+          properties: {
+            id: { type: 'string', readOnly: true },
+            name: { type: 'string' },
+          },
+        },
+      ],
+      anyOf: [
+        {
+          type: 'object',
+          required: ['status', 'fileName'],
+          properties: {
+            status: { type: 'string', readOnly: true },
+            fileName: { type: 'string' },
+          },
+        },
+      ],
+      allOf: [
+        {
+          type: 'object',
+          required: ['hash', 'title'],
+          properties: {
+            hash: { type: 'string', readOnly: true },
+            title: { type: 'string' },
+          },
+        },
+      ],
+    };
+
+    expect(toWriteSchema(schema)).toEqual({
+      oneOf: [
+        {
+          type: 'object',
+          required: ['name'],
+          properties: {
+            name: { type: 'string' },
+          },
+        },
+      ],
+      anyOf: [
+        {
+          type: 'object',
+          required: ['fileName'],
+          properties: {
+            fileName: { type: 'string' },
+          },
+        },
+      ],
+      allOf: [
+        {
+          type: 'object',
+          required: ['title'],
+          properties: {
+            title: { type: 'string' },
+          },
+        },
+      ],
+    });
+  });
+
+  it('does not mutate the original schema', () => {
+    const schema: oas31.SchemaObject = {
+      type: 'object',
+      required: ['id', 'name'],
+      properties: {
+        id: { type: 'string', readOnly: true },
+        name: { type: 'string' },
+      },
+    };
+    const original = JSON.stringify(schema);
+
+    toWriteSchema(schema);
+
+    expect(JSON.stringify(schema)).toBe(original);
+  });
+});

--- a/src/endpoint-microservice/restapi/queries/handlers/__tests__/open-api-schema.utils.spec.ts
+++ b/src/endpoint-microservice/restapi/queries/handlers/__tests__/open-api-schema.utils.spec.ts
@@ -2,6 +2,17 @@ import { oas31 } from 'openapi3-ts';
 import { toWriteSchema } from '../open-api-schema.utils';
 
 describe('toWriteSchema', () => {
+  it('returns a shallow copy for reference schemas', () => {
+    const schema: oas31.ReferenceObject = {
+      $ref: '#/components/schemas/File',
+    };
+
+    const result = toWriteSchema(schema);
+
+    expect(result).toEqual(schema);
+    expect(result).not.toBe(schema);
+  });
+
   it('omits readOnly properties and removes them from required', () => {
     const schema: oas31.SchemaObject = {
       type: 'object',

--- a/src/endpoint-microservice/restapi/queries/handlers/get-open-api-schema.handler.ts
+++ b/src/endpoint-microservice/restapi/queries/handlers/get-open-api-schema.handler.ts
@@ -14,6 +14,7 @@ import {
   createSingleRowPath,
   createTableInfoMap,
   getFilterAndSortSchemas,
+  toWriteSchema,
   TablePathInfo,
 } from './open-api-schema.utils';
 
@@ -104,9 +105,10 @@ export class GetOpenApiSchemaHandler implements IQueryHandler<GetOpenApiSchemaQu
 
       openApiJson.components ??= { schemas: {} };
       openApiJson.components.schemas ??= {};
-      openApiJson.components.schemas[info.schemaName] = resolveRefs(
-        schemaRow.data as JsonSchema,
-      );
+      const resolvedSchema = resolveRefs(schemaRow.data as JsonSchema);
+      openApiJson.components.schemas[info.schemaName] = resolvedSchema;
+      openApiJson.components.schemas[info.writeSchemaName] =
+        toWriteSchema(resolvedSchema);
     }
 
     return openApiJson;

--- a/src/endpoint-microservice/restapi/queries/handlers/open-api-schema.utils.ts
+++ b/src/endpoint-microservice/restapi/queries/handlers/open-api-schema.utils.ts
@@ -14,6 +14,7 @@ import {
 export interface TablePathInfo {
   rawTableId: string;
   schemaName: string;
+  writeSchemaName: string;
   tag: string;
 }
 
@@ -25,6 +26,117 @@ const getSchemaName = (tableId: string, projectName: string): string => {
   const name = capitalize(tableId);
   return `${prefix}${name}`;
 };
+
+const getWriteSchemaName = (schemaName: string): string =>
+  `${schemaName}WriteInput`;
+
+const cloneValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(cloneValue);
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [
+        key,
+        cloneValue(nestedValue),
+      ]),
+    );
+  }
+  return value;
+};
+
+const isSchemaObject = (
+  value: unknown,
+): value is oas31.SchemaObject | oas31.ReferenceObject =>
+  Boolean(value && typeof value === 'object');
+
+const isReadOnlySchema = (schema: oas31.SchemaObject | oas31.ReferenceObject) =>
+  !('$ref' in schema) && schema.readOnly === true;
+
+export function toWriteSchema(schema: oas31.SchemaObject): oas31.SchemaObject;
+export function toWriteSchema(
+  schema: oas31.ReferenceObject,
+): oas31.ReferenceObject;
+export function toWriteSchema(
+  schema: oas31.SchemaObject | oas31.ReferenceObject,
+): oas31.SchemaObject | oas31.ReferenceObject;
+export function toWriteSchema(
+  schema: oas31.SchemaObject | oas31.ReferenceObject,
+): oas31.SchemaObject | oas31.ReferenceObject {
+  if ('$ref' in schema) {
+    return { ...schema };
+  }
+
+  const result: oas31.SchemaObject = {};
+  const omittedProperties = new Set(
+    Object.entries(schema.properties ?? {})
+      .filter(([, propertySchema]) => isReadOnlySchema(propertySchema))
+      .map(([propertyName]) => propertyName),
+  );
+
+  for (const [key, value] of Object.entries(schema)) {
+    if (key === 'readOnly') {
+      continue;
+    }
+
+    if (key === 'properties' && isSchemaObject(value)) {
+      const properties: Record<
+        string,
+        oas31.SchemaObject | oas31.ReferenceObject
+      > = {};
+
+      for (const [propertyName, propertySchema] of Object.entries(
+        value as Record<string, oas31.SchemaObject | oas31.ReferenceObject>,
+      )) {
+        if (isReadOnlySchema(propertySchema)) {
+          omittedProperties.add(propertyName);
+          continue;
+        }
+
+        properties[propertyName] = toWriteSchema(propertySchema);
+      }
+
+      result.properties = properties;
+      continue;
+    }
+
+    if (key === 'required' && Array.isArray(value)) {
+      result.required = value.filter(
+        (field): field is string =>
+          typeof field === 'string' && !omittedProperties.has(field),
+      );
+      continue;
+    }
+
+    if (key === 'items' && isSchemaObject(value)) {
+      result.items = toWriteSchema(
+        value as oas31.SchemaObject | oas31.ReferenceObject,
+      );
+      continue;
+    }
+
+    if (key === 'additionalProperties' && isSchemaObject(value)) {
+      result.additionalProperties = toWriteSchema(
+        value as oas31.SchemaObject | oas31.ReferenceObject,
+      );
+      continue;
+    }
+
+    if (
+      (key === 'oneOf' || key === 'anyOf' || key === 'allOf') &&
+      Array.isArray(value)
+    ) {
+      (result as Record<string, unknown>)[key] = (
+        value as Array<oas31.SchemaObject | oas31.ReferenceObject>
+      ).map((entry) => toWriteSchema(entry));
+      continue;
+    }
+
+    (result as Record<string, unknown>)[key] = cloneValue(value);
+  }
+
+  return result;
+}
 
 const getCommonSchemaName = (name: string, projectName: string): string => {
   const prefix = capitalize(projectName);
@@ -464,6 +576,7 @@ export const createSingleRowPath = (
   isDraft: boolean,
 ): oas31.PathItemObject => {
   const schemaRef = `#/components/schemas/${info.schemaName}`;
+  const writeSchemaRef = `#/components/schemas/${info.writeSchemaName}`;
   const rowResponseSchema = getSingleRowResponseSchema(schemaRef);
   const patchOperationRef = `#/components/schemas/${getCommonSchemaName('PatchOperation', projectName)}`;
 
@@ -493,7 +606,7 @@ export const createSingleRowPath = (
             type: 'object',
             required: ['data'],
             properties: {
-              data: { $ref: schemaRef },
+              data: { $ref: writeSchemaRef },
             },
           },
         },
@@ -797,6 +910,7 @@ export const createBulkRowsPath = (
   projectName: string,
 ): oas31.PathItemObject => {
   const schemaRef = `#/components/schemas/${info.schemaName}`;
+  const writeSchemaRef = `#/components/schemas/${info.writeSchemaName}`;
   const patchOperationRef = `#/components/schemas/${getCommonSchemaName('PatchOperation', projectName)}`;
   const bulkResponseSchema = getBulkResponseSchema(schemaRef);
 
@@ -806,7 +920,7 @@ export const createBulkRowsPath = (
       verb: 'Creates',
       requestDescription: 'Array of rows to create',
       responseDescription: 'Created rows',
-      getRequestSchema: () => getBulkRowsRequestSchema(schemaRef),
+      getRequestSchema: () => getBulkRowsRequestSchema(writeSchemaRef),
       getResponseSchema: () => bulkResponseSchema,
     }),
     put: createBulkOperation(info, {
@@ -814,7 +928,7 @@ export const createBulkRowsPath = (
       verb: 'Updates',
       requestDescription: 'Array of rows to update',
       responseDescription: 'Updated rows',
-      getRequestSchema: () => getBulkRowsRequestSchema(schemaRef),
+      getRequestSchema: () => getBulkRowsRequestSchema(writeSchemaRef),
       getResponseSchema: () => bulkResponseSchema,
     }),
     patch: createBulkOperation(info, {
@@ -844,9 +958,11 @@ export const createTableInfoMap = (
   const map = new Map<string, TablePathInfo>();
 
   for (const rawTableId of tableIds) {
+    const schemaName = getSchemaName(rawTableId, projectName);
     map.set(rawTableId, {
       rawTableId,
-      schemaName: getSchemaName(rawTableId, projectName),
+      schemaName,
+      writeSchemaName: getWriteSchemaName(schemaName),
       tag: rawTableId,
     });
   }


### PR DESCRIPTION
Fixes revisium/qa#20

## Summary
- add separate `*WriteInput` OpenAPI schemas for table write payloads
- recursively omit `readOnly` properties and remove them from `required`
- use write schemas for single/bulk create and update request bodies
- keep response/output schemas unchanged

## Validation
- `npx jest src/endpoint-microservice/restapi/queries/handlers/__tests__/open-api-schema.utils.spec.ts src/endpoint-microservice/restapi/__tests__/restapi-openapi-file-input.spec.ts src/endpoint-microservice/restapi/__tests__/openapi-schema.snapshot.spec.ts --runInBand`
- `npm run tsc`
- `npm run lint:ci`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API documentation now generates separate write-input schemas for create/update operations, providing clearer request structures and reducing unnecessary required fields. File upload fields are simplified in write requests.

* **Tests**
  * Added integration test for OpenAPI write-input schema generation with file field handling.
  * Added test coverage for write-schema transformation logic.
  * Updated API documentation snapshots.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/revisium/revisium-endpoint/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->